### PR TITLE
feat: add PSICHIC-prod/ optimized inference pipeline

### DIFF
--- a/PSICHIC-prod/README.md
+++ b/PSICHIC-prod/README.md
@@ -1,0 +1,88 @@
+# PSICHIC-prod
+
+Optimized production inference pipeline for PSICHIC drug-protein interaction screening on NVIDIA GPUs.
+
+This directory is **additive** -- the original `screening.py` and `models/` are untouched. Use `PSICHIC-prod/` when you need fast, large-scale screening.
+
+## Quick start
+
+```bash
+cd PSICHIC-prod
+
+# Basic screening
+python inference.py --fasta proteins.fasta --smiles ligands.csv
+
+# Large-scale with top-K (ZINC-scale)
+python inference.py --fasta proteins.fasta --smiles zinc.csv \
+    --top-k 100 --batch-size 128
+
+# Multitask model (adds agonist/antagonist/nonbinder columns)
+python inference.py --fasta proteins.fasta --smiles ligands.csv \
+    --model multitask_PSICHIC
+
+# With interpretation outputs
+python inference.py --fasta proteins.fasta --smiles ligands.csv \
+    --top-k 50 --save-interpret
+```
+
+## What's different from `screening.py`
+
+| Feature | `screening.py` | `PSICHIC-prod/inference.py` |
+|---------|----------------|----------------------------|
+| Model | `models/net.py` (original) | `psichic_model.py` (compile-friendly, no `torch_scatter`) |
+| ESM-2 | Serial, one sequence at a time | Batched by length bin (`esm_batched/`) |
+| Ligand featurization | In dataloader, per-item | Multiprocessing + LMDB cache |
+| Scoring | Loads all pairs into memory | Streaming chunks (10K ligands/chunk) |
+| AMP | No | Yes (Tensor Core acceleration) |
+| Top-K | No | Per-protein heapq, memory-bounded |
+| Interpretation | `--interpret` flag | `--save-interpret --top-k N` (two-pass) |
+| Scale | ~1K ligands | Millions (ZINC-scale) |
+
+## Performance (A100 80GB)
+
+| Metric | Original | PSICHIC-prod |
+|--------|----------|--------------|
+| Model scoring | 55 pairs/s | **223 pairs/s** (4x, AMP + bs=128) |
+| Protein preprocessing | ~21 min (12.6K proteins) | **18s** with cache (68x) |
+| Ligand featurization | ~335/s serial | **~2,500/s** (8 workers) or **~100K/s** (cache hit) |
+
+## CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--fasta` | required | Protein FASTA file |
+| `--smiles` | required | SMILES file (CSV, SMI, or tar.gz) |
+| `--output` | `results.csv` | Output CSV path |
+| `--model` | `PDBv2020_PSICHIC` | Model weights (`PDBv2020_PSICHIC` or `multitask_PSICHIC`) |
+| `--batch-size` | `128` | Inference batch size |
+| `--device` | `cuda:0` | CUDA device |
+| `--top-k` | None | Keep top-K ligands per protein |
+| `--save-interpret` | off | Save per-residue interpretation CSVs (requires `--top-k`) |
+| `--interpret-dir` | `interpretation_results/` | Interpretation output directory |
+| `--no-cache` | off | Skip protein cache |
+| `--ligand-cache-dir` | `cache/` | LMDB ligand cache directory |
+| `--no-ligand-cache` | off | In-memory mode (max 50K ligands) |
+| `--ligand-workers` | auto | Number of ligand preprocessing workers (0=auto, max 8) |
+| `--amp` | on | Mixed precision inference |
+
+## File structure
+
+```
+PSICHIC-prod/
+  inference.py          # Production entry point
+  psichic_model.py      # Self-contained model (no torch_scatter dependency)
+  esm_batched/          # Batched ESM-2 protein preprocessing
+  cache/                # Created at runtime
+    proteins/           # Per-protein .pt shards
+    ligands_v1.lmdb/    # LMDB ligand feature cache
+```
+
+Shared resources from parent repo (not duplicated):
+- `../trained_weights/` -- model checkpoints
+- `../utils/` -- ligand/protein featurization, dataset utilities
+
+## Requirements
+
+Same as PSICHIC, plus:
+- `lmdb` (`pip install lmdb`)
+- `torch_scatter` is **not** required (replaced with `torch_geometric.utils.scatter`)

--- a/PSICHIC-prod/esm_batched/esm_batched.py
+++ b/PSICHIC-prod/esm_batched/esm_batched.py
@@ -1,0 +1,342 @@
+"""Batched ESM-2 protein featurization for PSICHIC.
+
+Replaces the serial per-sequence loop in PSICHIC/utils/protein_init.py
+with length-binned batch processing. Target: 4-6x preprocessing speedup.
+
+Design decisions:
+- fp32 only: contact_map() hard-thresholds probabilities at 0.5 to build
+  edge_index. fp16 drift produces discrete graph topology changes.
+- repr_layers=[33] only: approach='last' uses only the final layer, so
+  requesting all 33 layers wastes ~32x memory.
+- Sequences >700 aa: preserve the original sliding-window merge logic
+  exactly (cannot batch naively due to overlapping-window averaging).
+- Adaptive batch sizes by length bin to avoid OOM on A100 80GB.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from typing import Any
+
+import numpy as np
+import torch
+
+log = logging.getLogger(__name__)
+
+# Length bins → max batch sizes (A100 80GB with ESM-2 650M ~2.5GB)
+LENGTH_BIN_BATCH_SIZES: list[tuple[int, int]] = [
+    (300, 8),    # <=300 residues
+    (500, 4),    # 301-500
+    (700, 2),    # 501-700
+]
+SLIDING_WINDOW_THRESHOLD = 700
+
+
+def _load_esm_model(device: torch.device) -> tuple[Any, Any, Any]:
+    """Load ESM-2 650M model, alphabet, and batch_converter."""
+    import esm
+
+    model, alphabet = esm.pretrained.load_model_and_alphabet("esm2_t33_650M_UR50D")
+    model.eval()
+    model = model.to(device)
+    batch_converter = alphabet.get_batch_converter()
+    return model, alphabet, batch_converter
+
+
+def _get_batch_size_for_length(seq_len: int) -> int:
+    """Return adaptive batch size based on sequence length."""
+    for max_len, bs in LENGTH_BIN_BATCH_SIZES:
+        if seq_len <= max_len:
+            return bs
+    return 1
+
+
+def _bin_sequences(
+    seqs: list[str],
+) -> dict[str, list[str]]:
+    """Group sequences into length bins for efficient batching.
+
+    Returns dict mapping bin label to list of sequences, sorted by length
+    within each bin to minimize padding waste.
+    """
+    bins: dict[str, list[str]] = {
+        "short_300": [],
+        "medium_500": [],
+        "long_700": [],
+        "sliding": [],
+    }
+    for seq in seqs:
+        n = len(seq)
+        if n <= 300:
+            bins["short_300"].append(seq)
+        elif n <= 500:
+            bins["medium_500"].append(seq)
+        elif n <= 700:
+            bins["long_700"].append(seq)
+        else:
+            bins["sliding"].append(seq)
+
+    # Sort within each bin by length (shortest first = less padding)
+    for key in bins:
+        bins[key].sort(key=len)
+
+    return bins
+
+
+def _process_short_batch(
+    model: Any,
+    batch_converter: Any,
+    seqs: list[str],
+    device: torch.device,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Process a batch of short sequences (<=700 aa) through ESM-2.
+
+    Returns list of (token_representation, contact_prob_map) tuples,
+    one per sequence, in the same order as input seqs.
+    """
+    # Prepare batch for ESM
+    data = [(f"seq_{i}", seq) for i, seq in enumerate(seqs)]
+    _labels, _strs, batch_tokens = batch_converter(data)
+    batch_tokens = batch_tokens.to(device, non_blocking=True)
+
+    with torch.inference_mode():
+        results = model(batch_tokens, repr_layers=[33], return_contacts=True)
+
+    # Extract per-sequence results
+    outputs: list[tuple[np.ndarray, np.ndarray]] = []
+    for i, seq in enumerate(seqs):
+        seq_len = len(seq)
+
+        # Token representation: layer 33 only (approach='last')
+        # Shape: (batch, seq_len+2, 1280) — +2 for BOS/EOS tokens
+        token_repr = results["representations"][33][i].cpu().numpy()
+        # Strip BOS/EOS tokens: keep positions [1 : seq_len+1]
+        token_repr = token_repr[1: seq_len + 1]
+
+        # Contact map: (batch, padded_len, padded_len)
+        # ESM contact_head already removes BOS/EOS, so shape is (padded_len-2, padded_len-2)
+        # But we need only the first seq_len x seq_len submatrix
+        contact_map_proba = results["contacts"][i].cpu().numpy()
+        contact_map_proba = contact_map_proba[:seq_len, :seq_len]
+
+        outputs.append((token_repr, contact_map_proba))
+
+    return outputs
+
+
+def _process_sliding_window(
+    model: Any,
+    batch_converter: Any,
+    seq: str,
+    device: torch.device,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Process a long sequence (>700 aa) using the original sliding-window merge.
+
+    This is an exact copy of the logic from PSICHIC/utils/protein_init.py:200-262,
+    with two changes: repr_layers=[33] instead of [1..33], and torch.inference_mode().
+    """
+    layer = 33
+    dim = 1280
+    pro_id = "A"
+
+    contact_prob_map = np.zeros((len(seq), len(seq)), dtype=np.float32)
+    token_representation = np.zeros((len(seq), dim), dtype=np.float32)
+    interval = 350
+    num_windows = math.ceil(len(seq) / interval)
+
+    for s in range(num_windows):
+        start = s * interval
+        end = min((s + 2) * interval, len(seq))
+
+        temp_seq = seq[start:end]
+        temp_data = [(pro_id, temp_seq)]
+        _labels, _strs, batch_tokens = batch_converter(temp_data)
+        batch_tokens = batch_tokens.to(device, non_blocking=True)
+
+        with torch.inference_mode():
+            results = model(
+                batch_tokens,
+                repr_layers=[layer],
+                return_contacts=True,
+            )
+
+        # --- Contact map merging (averaging overlaps) ---
+        row, col = np.where(contact_prob_map[start:end, start:end] != 0)
+        row = row + start
+        col = col + start
+        contact_prob_map[start:end, start:end] = (
+            contact_prob_map[start:end, start:end]
+            + results["contacts"][0].cpu().numpy()
+        )
+        contact_prob_map[row, col] = contact_prob_map[row, col] / 2.0
+
+        # --- Token representation merging (averaging overlaps) ---
+        # With repr_layers=[33], results['representations'][33] has shape (1, L+2, dim)
+        subtoken_repr = results["representations"][layer][0].cpu().numpy()
+        subtoken_repr = subtoken_repr[1: len(temp_seq) + 1]
+
+        trow = np.where(token_representation[start:end].sum(axis=-1) != 0)[0]
+        trow = trow + start
+        token_representation[start:end] = token_representation[start:end] + subtoken_repr
+        token_representation[trow] = token_representation[trow] / 2.0
+
+        if end == len(seq):
+            break
+
+    return token_representation, contact_prob_map
+
+
+def _replace_non_standard_residues(seq: str) -> str:
+    """Replace U and B with X for ESM compatibility."""
+    return seq.replace("U", "X").replace("B", "X")
+
+
+def batched_protein_init(
+    seqs: list[str],
+    device: torch.device | None = None,
+    seq_feature_fn: Any = None,
+    contact_map_fn: Any = None,
+) -> dict[str, dict[str, Any]]:
+    """Batch-process protein sequences through ESM-2 and build PSICHIC features.
+
+    Drop-in replacement for PSICHIC/utils/protein_init.py:protein_init().
+    Returns the same dict format keyed by sequence.
+
+    Args:
+        seqs: List of unique protein sequences.
+        device: CUDA device. Defaults to cuda:0.
+        seq_feature_fn: Function to compute residue features (default: import from PSICHIC).
+        contact_map_fn: Function to build contact graph (default: import from PSICHIC).
+
+    Returns:
+        Dict[seq] → {seq, seq_feat, token_representation, num_nodes,
+                      node_pos, edge_index, edge_weight}
+    """
+    if device is None:
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    # Lazy import PSICHIC utilities
+    if seq_feature_fn is None or contact_map_fn is None:
+        import sys as _sys
+        from pathlib import Path as _Path
+
+        _psichic_dir = str(_Path(__file__).resolve().parents[1] / "PSICHIC")
+        if _psichic_dir not in _sys.path:
+            _sys.path.insert(0, _psichic_dir)
+        from utils.protein_init import contact_map as _contact_map
+        from utils.protein_init import seq_feature as _seq_feature
+
+        if seq_feature_fn is None:
+            seq_feature_fn = _seq_feature
+        if contact_map_fn is None:
+            contact_map_fn = _contact_map
+
+    # Clean sequences
+    cleaned_seqs = [_replace_non_standard_residues(s) for s in seqs]
+    # Map original → cleaned for output keying
+    seq_map = dict(zip(seqs, cleaned_seqs))
+
+    # Deduplicate
+    unique_cleaned = list(dict.fromkeys(cleaned_seqs))
+    log.info("Processing %d unique proteins (%d input)", len(unique_cleaned), len(seqs))
+
+    if not unique_cleaned:
+        return {}
+
+    # Load ESM model
+    t0 = time.perf_counter()
+    model, _alphabet, batch_converter = _load_esm_model(device)
+    log.info("ESM-2 loaded in %.1fs", time.perf_counter() - t0)
+
+    # Bin sequences by length
+    bins = _bin_sequences(unique_cleaned)
+    bin_counts = {k: len(v) for k, v in bins.items() if v}
+    log.info("Length bins: %s", bin_counts)
+
+    # Process all sequences, collecting (token_repr, contact_prob_map) per sequence
+    esm_results: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+    t_start = time.perf_counter()
+
+    # Process short/medium/long bins (<=700) in batches
+    for bin_name in ["short_300", "medium_500", "long_700"]:
+        bin_seqs = bins[bin_name]
+        if not bin_seqs:
+            continue
+
+        max_len = max(len(s) for s in bin_seqs)
+        batch_size = _get_batch_size_for_length(max_len)
+        log.info(
+            "Processing %s: %d seqs, bs=%d",
+            bin_name, len(bin_seqs), batch_size,
+        )
+
+        for batch_start in range(0, len(bin_seqs), batch_size):
+            batch = bin_seqs[batch_start: batch_start + batch_size]
+            batch_outputs = _process_short_batch(model, batch_converter, batch, device)
+            for seq, (token_repr, contact_proba) in zip(batch, batch_outputs):
+                esm_results[seq] = (token_repr, contact_proba)
+
+    # Process sliding window sequences (>700) one at a time
+    sliding_seqs = bins["sliding"]
+    if sliding_seqs:
+        log.info("Processing sliding window: %d seqs (>700 aa)", len(sliding_seqs))
+        for i, seq in enumerate(sliding_seqs):
+            token_repr, contact_proba = _process_sliding_window(
+                model, batch_converter, seq, device,
+            )
+            esm_results[seq] = (token_repr, contact_proba)
+            if (i + 1) % 100 == 0:
+                log.info("  Sliding window: %d/%d done", i + 1, len(sliding_seqs))
+
+    esm_time = time.perf_counter() - t_start
+    log.info(
+        "ESM-2 processing complete: %.1fs (%.3f s/protein)",
+        esm_time, esm_time / max(len(unique_cleaned), 1),
+    )
+
+    # Free ESM model
+    del model
+    torch.cuda.empty_cache()
+
+    # Build PSICHIC feature dicts, keyed by ORIGINAL input sequence so that
+    # callers (precompute_proteins, cache lookups) can use the same key they
+    # passed in.  Internally we deduplicate on the cleaned sequence so that
+    # U/B-containing variants are only computed once.
+    result_dict: dict[str, dict[str, Any]] = {}
+    cleaned_features: dict[str, dict[str, Any]] = {}  # cleaned seq → features (dedup)
+
+    for orig_seq in seqs:
+        cleaned = seq_map[orig_seq]
+        if orig_seq in result_dict:
+            # Exact duplicate input — skip
+            continue
+
+        if cleaned not in cleaned_features:
+            token_repr_np, contact_proba_np = esm_results[cleaned]
+            contact_proba_tensor = torch.from_numpy(contact_proba_np)
+
+            if len(contact_proba_tensor) != len(cleaned):
+                raise RuntimeError(
+                    f"Contact map length {len(contact_proba_tensor)} != seq length {len(cleaned)}"
+                )
+
+            edge_index, edge_weight = contact_map_fn(contact_proba_tensor)
+            sf = seq_feature_fn(cleaned)
+
+            cleaned_features[cleaned] = {
+                "seq": cleaned,
+                "seq_feat": torch.from_numpy(sf),
+                "token_representation": torch.from_numpy(token_repr_np).half(),
+                "num_nodes": len(cleaned),
+                "node_pos": torch.arange(len(cleaned)).reshape(-1, 1),
+                "edge_index": edge_index,
+                "edge_weight": edge_weight,
+            }
+
+        result_dict[orig_seq] = cleaned_features[cleaned]
+
+    log.info("Built feature dicts for %d proteins", len(result_dict))
+    return result_dict

--- a/PSICHIC-prod/inference.py
+++ b/PSICHIC-prod/inference.py
@@ -1,0 +1,1486 @@
+#!/usr/bin/env python3
+"""PSICHIC optimized screening pipeline.
+
+Takes any FASTA file (protein sequences) + any SMILES file (CSV, SMI, or
+tar.gz-wrapped CSV) and screens all protein-ligand pairs using the
+optimized PSICHIC model with batched ESM-2 preprocessing.
+
+Pipeline:
+  1. Parse inputs (FASTA + SMILES)
+  2. Precompute ligand features (LMDB cache + multiprocessing, CPU-only)
+  3. Precompute protein embeddings (batched ESM-2, cached to disk)
+  4. Load PSICHIC model
+  5. Stream scoring in ligand chunks (AMP + bs=128)
+  6. Output ranked CSV + optional interpretation
+
+Usage:
+    # Basic screening
+    python inference.py --fasta proteins.fasta --smiles ligands.csv
+
+    # With a tar.gz SMILES file
+    python inference.py --fasta proteins.fasta --smiles zinc20_smiles.csv.tar.gz
+
+    # Custom output and batch size
+    python inference.py --fasta proteins.fasta --smiles ligands.smi \\
+        --output results.csv --batch-size 256
+
+    # Large-scale screening with top-K
+    python inference.py --fasta proteins.fasta --smiles zinc.csv \\
+        --top-k 100 --save-interpret
+
+    # Multitask model (adds classification columns)
+    python inference.py --fasta proteins.fasta --smiles ligands.csv \\
+        --model multitask_PSICHIC
+
+    # Skip protein cache (recompute every time)
+    python inference.py --fasta proteins.fasta --smiles ligands.csv --no-cache
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import heapq
+import io
+import itertools
+import json
+import logging
+import os
+import re
+import sys
+import tarfile
+import tempfile
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import multiprocessing
+
+import numpy as np
+import torch
+from torch_geometric.data import Batch
+
+# spawn start method is set in main() to avoid side effects on import.
+
+# ---------------------------------------------------------------------------
+# Path setup — BEFORE any CUDA init
+# ---------------------------------------------------------------------------
+PROD_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PROD_DIR.parent  # huankoh/PSICHIC repo root
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(PROD_DIR))
+
+from utils.dataset import MultiGraphData  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+DEFAULT_PROTEIN_CACHE_DIR = PROD_DIR / "cache" / "proteins"
+DEFAULT_LIGAND_CACHE_DIR = PROD_DIR / "cache"
+LIGAND_LMDB_NAME = "ligands_v1.lmdb"
+
+# Scale guard threshold
+MAX_PAIRS_WITHOUT_TOPK = 10_000_000
+
+# Streaming chunk size (number of original SMILES per chunk)
+LIGAND_CHUNK_SIZE = 10_000
+
+# Multiprocessing chunk size (SMILES per worker task).
+# Large chunks reduce the number of futures (and shared-memory FDs) in flight.
+MP_CHUNK_SIZE = 2000
+
+
+def _batch_iter(it, n: int):
+    """Yield successive n-sized lists from an iterator without materializing all at once."""
+    while True:
+        batch = list(itertools.islice(it, n))
+        if not batch:
+            break
+        yield batch
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_fasta(path: Path) -> dict[str, str]:
+    """Parse a FASTA file into {header_id: sequence}.
+
+    Handles multi-line sequences. The header ID is the first whitespace-
+    delimited token after '>'.
+    """
+    proteins: dict[str, str] = {}
+    current_id: str | None = None
+    current_seq: list[str] = []
+
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if current_id is not None:
+                    proteins[current_id] = "".join(current_seq)
+                current_id = line[1:].split()[0]
+                current_seq = []
+            else:
+                current_seq.append(line)
+
+    if current_id is not None:
+        proteins[current_id] = "".join(current_seq)
+
+    log.info("Parsed %d protein(s) from %s", len(proteins), path.name)
+    return proteins
+
+
+def parse_smiles(path: Path) -> list[str]:
+    """Parse SMILES strings from CSV, SMI, or tar.gz-wrapped CSV.
+
+    Supported formats:
+    - .csv: expects a column named 'smiles' or 'SMILES' (case-insensitive)
+    - .smi: one SMILES per line (optionally followed by whitespace + name)
+    - .tar.gz / .tgz: extracts the first CSV inside, then parses as CSV
+
+    Returns deduplicated list of SMILES strings.
+    """
+    actual_path = path
+    tmp_dir = None
+
+    if path.name.endswith(".tar.gz") or path.name.endswith(".tgz"):
+        log.info("Extracting tar.gz archive: %s", path.name)
+        tmp_dir = tempfile.mkdtemp(prefix="psichic_smiles_")
+        with tarfile.open(path, "r:gz") as tar:
+            tmp_dir_real = os.path.realpath(tmp_dir)
+            members = []
+            for m in tar.getmembers():
+                if not m.isfile():
+                    continue
+                # Reject absolute paths and path traversal components.
+                # os.path.join with an absolute member name would escape tmp_dir,
+                # so we must check before constructing the destination path.
+                dest = os.path.realpath(os.path.join(tmp_dir_real, m.name))
+                if not dest.startswith(tmp_dir_real + os.sep):
+                    log.warning("Skipping unsafe tar member: %r", m.name)
+                    continue
+                members.append(m)
+            # Filter out macOS resource fork files (._* prefix)
+            members = [m for m in members if not os.path.basename(m.name).startswith("._")]
+            csv_members = [m for m in members if m.name.endswith(".csv")]
+            if not csv_members:
+                smi_members = [m for m in members if m.name.endswith(".smi")]
+                target = smi_members[0] if smi_members else members[0]
+            else:
+                target = csv_members[0]
+            tar.extract(target, path=tmp_dir, filter="data")
+            actual_path = Path(tmp_dir) / target.name
+            log.info("Extracted: %s", actual_path.name)
+
+    try:
+        smiles_list = _parse_smiles_file(actual_path)
+    finally:
+        if tmp_dir is not None:
+            import shutil
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    return smiles_list
+
+
+def _parse_smiles_file(path: Path) -> list[str]:
+    """Parse SMILES from a plain CSV or SMI file."""
+    suffix = path.suffix.lower()
+
+    if suffix == ".csv":
+        return _parse_smiles_csv(path)
+    elif suffix in (".smi", ".smiles"):
+        return _parse_smiles_smi(path)
+    else:
+        try:
+            return _parse_smiles_csv(path)
+        except (KeyError, csv.Error):
+            return _parse_smiles_smi(path)
+
+
+def _parse_smiles_csv(path: Path) -> list[str]:
+    """Parse SMILES from a CSV file with a 'smiles' column."""
+    import pandas as pd
+
+    df = pd.read_csv(path)
+    smiles_col = None
+    for col in df.columns:
+        if col.lower() in ("smiles", "smi", "canonical_smiles", "compound_smiles"):
+            smiles_col = col
+            break
+    if smiles_col is None:
+        smiles_col = df.columns[0]
+        log.warning("No 'smiles' column found, using first column: '%s'", smiles_col)
+
+    raw = df[smiles_col].dropna().astype(str).str.strip().tolist()
+    seen: set[str] = set()
+    unique: list[str] = []
+    for s in raw:
+        if s and s not in seen:
+            seen.add(s)
+            unique.append(s)
+
+    log.info("Parsed %d unique SMILES from %s (column '%s')", len(unique), path.name, smiles_col)
+    return unique
+
+
+def _parse_smiles_smi(path: Path) -> list[str]:
+    """Parse SMILES from a .smi file (one per line, optional name after space)."""
+    seen: set[str] = set()
+    unique: list[str] = []
+
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            smi = line.split()[0]
+            if smi and smi not in seen:
+                seen.add(smi)
+                unique.append(smi)
+
+    log.info("Parsed %d unique SMILES from %s", len(unique), path.name)
+    return unique
+
+
+# ---------------------------------------------------------------------------
+# Canonical SMILES utilities
+# ---------------------------------------------------------------------------
+
+
+def _build_canonical_map(smiles_list: list[str]) -> tuple[dict[str, str], list[str]]:
+    """Build mapping from original SMILES to canonical form.
+
+    Returns:
+        canonical_map: {original_smiles: canonical_smiles}
+        failed: list of unparseable SMILES
+    """
+    from rdkit import Chem
+    canonical_map: dict[str, str] = {}
+    failed: list[str] = []
+
+    for smi in smiles_list:
+        mol = Chem.MolFromSmiles(smi)
+        if mol is None:
+            failed.append(smi)
+            continue
+        canonical_map[smi] = Chem.MolToSmiles(mol)
+
+    if failed:
+        log.warning("Failed to canonicalize %d SMILES (first 10): %s", len(failed), failed[:10])
+
+    unique_canonical = len(set(canonical_map.values()))
+    log.info(
+        "Canonical map: %d input → %d unique canonical (%d deduped)",
+        len(canonical_map), unique_canonical, len(canonical_map) - unique_canonical,
+    )
+    return canonical_map, failed
+
+
+# ---------------------------------------------------------------------------
+# Protein preprocessing (batched ESM-2 with disk cache)
+# ---------------------------------------------------------------------------
+
+
+def _seq_hash(seq: str) -> str:
+    """SHA-256 hash of a protein sequence for cache keying."""
+    return hashlib.sha256(seq.encode("utf-8")).hexdigest()
+
+
+def precompute_proteins(
+    proteins: dict[str, str],
+    device: torch.device,
+    cache_dir: Path | None = DEFAULT_PROTEIN_CACHE_DIR,
+) -> dict[str, dict[str, Any]]:
+    """Precompute protein features using batched ESM-2.
+
+    Checks disk cache first; only computes missing proteins. Saves new
+    results to cache for future runs.
+
+    Returns dict keyed by protein sequence -> feature dict.
+    """
+    unique_seqs = list(set(proteins.values()))
+    log.info("Total unique protein sequences: %d", len(unique_seqs))
+
+    cached: dict[str, dict] = {}
+    missing_seqs: list[str] = []
+
+    if cache_dir is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        for seq in unique_seqs:
+            h = _seq_hash(seq)
+            shard_path = cache_dir / f"{h}.pt"
+            if shard_path.exists():
+                features = torch.load(shard_path, weights_only=True, map_location="cpu")
+                features["seq_feat"] = features["seq_feat"].float()
+                features["token_representation"] = features["token_representation"].float()
+                features["num_nodes"] = len(features["seq"])
+                features["node_pos"] = torch.arange(len(features["seq"])).reshape(-1, 1)
+                features["edge_weight"] = features["edge_weight"].float()
+                cached[seq] = features
+            else:
+                missing_seqs.append(seq)
+        log.info("Protein cache: %d hit, %d miss", len(cached), len(missing_seqs))
+    else:
+        missing_seqs = unique_seqs
+        log.info("Cache disabled, computing all %d proteins", len(missing_seqs))
+
+    if missing_seqs:
+        from esm_batched.esm_batched import batched_protein_init
+
+        t0 = time.perf_counter()
+        new_features = batched_protein_init(missing_seqs, device=device)
+        elapsed = time.perf_counter() - t0
+        log.info(
+            "Batched ESM-2: %d proteins in %.1fs (%.2f proteins/s)",
+            len(missing_seqs), elapsed, len(missing_seqs) / elapsed if elapsed > 0 else 0,
+        )
+
+        if cache_dir is not None:
+            for seq, feat in new_features.items():
+                h = _seq_hash(seq)
+                shard_path = cache_dir / f"{h}.pt"
+                fd, tmp_path = tempfile.mkstemp(dir=str(cache_dir), suffix=".pt.tmp")
+                os.close(fd)
+                try:
+                    torch.save(feat, tmp_path)
+                    os.rename(tmp_path, str(shard_path))
+                except Exception:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
+            log.info("Saved %d protein shards to cache", len(new_features))
+
+        for seq, feat in new_features.items():
+            feat["seq_feat"] = feat["seq_feat"].float()
+            feat["token_representation"] = feat["token_representation"].float()
+            feat["num_nodes"] = len(feat["seq"])
+            feat["node_pos"] = torch.arange(len(feat["seq"])).reshape(-1, 1)
+            feat["edge_weight"] = feat["edge_weight"].float()
+
+        cached.update(new_features)
+
+    return cached
+
+
+# ---------------------------------------------------------------------------
+# Ligand preprocessing — post-transform helper
+# ---------------------------------------------------------------------------
+
+
+def _post_transform_ligand(raw: dict[str, Any]) -> dict[str, Any]:
+    """Apply cache_transform to raw ligand_init output (same as ProteinMoleculeDataset)."""
+    v = dict(raw)  # shallow copy to avoid mutating input
+    v["atom_idx"] = v["atom_idx"].long().view(-1, 1)
+    v["atom_feature"] = v["atom_feature"].float()
+    adj = v["bond_feature"].long()
+    mol_edge_index = adj.nonzero(as_tuple=False).t().contiguous()
+    v["atom_edge_index"] = mol_edge_index
+    v["atom_edge_attr"] = adj[mol_edge_index[0], mol_edge_index[1]].long()
+    v["atom_num_nodes"] = v["atom_idx"].shape[0]
+    v["x_clique"] = v["x_clique"].long().view(-1, 1)
+    v["clique_num_nodes"] = v["x_clique"].shape[0]
+    v["tree_edge_index"] = v["tree_edge_index"].long()
+    v["atom2clique_index"] = v["atom2clique_index"].long()
+    return v
+
+
+# ---------------------------------------------------------------------------
+# LMDB ligand cache
+# ---------------------------------------------------------------------------
+
+
+def _open_lmdb(path: Path, map_size: int = 10 * 1024**3) -> Any:
+    """Open or create an LMDB environment with secure permissions."""
+    import lmdb
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return lmdb.open(str(path), map_size=map_size)
+
+
+def _lmdb_put_batch(env: Any, items: list[tuple[bytes, bytes]]) -> None:
+    """Write a batch of (key, value) pairs to LMDB, auto-resizing on MapFullError."""
+    import lmdb
+    while True:
+        try:
+            with env.begin(write=True) as txn:
+                for key, value in items:
+                    txn.put(key, value)
+            return
+        except lmdb.MapFullError:
+            new_size = env.info()["map_size"] * 2
+            log.info("LMDB MapFullError — resizing to %d GB", new_size // (1024**3))
+            env.set_mapsize(new_size)
+
+
+# Top-level function for multiprocessing (must be picklable)
+def _process_ligand_chunk(smiles_chunk: list[str]) -> list[tuple[str, bytes | None, str | None]]:
+    """Process a chunk of SMILES into serialized feature dicts.
+
+    Returns serialized bytes (not raw tensors) to avoid shared-memory FD
+    exhaustion when sending results through multiprocessing queues.
+
+    Each entry: (canonical_smiles, serialized_bytes_or_None, error_or_None)
+    Must be top-level and import inside body for spawn worker compatibility.
+    """
+    # Import within worker to avoid CUDA fork issues
+    # Add repo root (parent of PSICHIC-prod/) so utils/ is importable
+    repo_root = str(Path(__file__).resolve().parent.parent)
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    from utils.ligand_init import smiles2graph
+    import torch as _torch
+
+    results: list[tuple[str, bytes | None, str | None]] = []
+    for smi in smiles_chunk:
+        try:
+            raw = smiles2graph(smi)
+            transformed = _post_transform_ligand(raw)
+            # Serialize to bytes inside worker to avoid shared-memory FDs
+            buf = io.BytesIO()
+            _torch.save(transformed, buf)
+            results.append((smi, buf.getvalue(), None))
+        except Exception as exc:
+            results.append((smi, None, str(exc)))
+    return results
+
+
+def precompute_ligands_lmdb(
+    canonical_smiles_set: set[str],
+    cache_dir: Path,
+    num_workers: int,
+) -> tuple[Path, int, int]:
+    """Precompute ligand features into LMDB, using multiprocessing.
+
+    Must be called BEFORE any CUDA initialization.
+
+    Returns:
+        lmdb_path: Path to LMDB directory
+        hits: number of cache hits
+        misses: number computed
+    """
+    lmdb_path = cache_dir / LIGAND_LMDB_NAME
+    env = _open_lmdb(lmdb_path)
+
+    try:
+        # Check cache hits
+        missing: list[str] = []
+        hits = 0
+        with env.begin() as txn:
+            for csmi in canonical_smiles_set:
+                if txn.get(csmi.encode("utf-8")) is not None:
+                    hits += 1
+                else:
+                    missing.append(csmi)
+
+        log.info("LMDB ligand cache: %d hit, %d miss", hits, len(missing))
+
+        if not missing:
+            return lmdb_path, hits, 0
+
+        # Process missing SMILES with multiprocessing
+        if num_workers <= 0:
+            num_workers = max(1, (os.cpu_count() or 1) - 2)
+
+        log.info(
+            "Computing %d ligand features (%d workers, chunk_size=%d)...",
+            len(missing), num_workers, MP_CHUNK_SIZE,
+        )
+
+        chunks = [missing[i:i + MP_CHUNK_SIZE] for i in range(0, len(missing), MP_CHUNK_SIZE)]
+        computed = 0
+        failed_count = 0
+        t0 = time.perf_counter()
+
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            futures = {executor.submit(_process_ligand_chunk, chunk): i for i, chunk in enumerate(chunks)}
+            for future in as_completed(futures):
+                results = future.result()
+                # Collect items for batch LMDB write
+                write_items: list[tuple[bytes, bytes]] = []
+                for csmi, feat_bytes, error in results:
+                    if error is not None:
+                        failed_count += 1
+                    else:
+                        key = csmi.encode("utf-8")
+                        write_items.append((key, feat_bytes))
+                        computed += 1
+
+                if write_items:
+                    _lmdb_put_batch(env, write_items)
+
+                # Progress
+                done_chunks = sum(1 for f in futures if f.done())
+                if done_chunks % max(1, len(chunks) // 10) == 0 or done_chunks == len(chunks):
+                    elapsed = time.perf_counter() - t0
+                    rate = computed / elapsed if elapsed > 0 else 0
+                    log.info(
+                        "  Ligands: %d/%d computed (%.0f/s), %d failed",
+                        computed, len(missing), rate, failed_count,
+                    )
+    finally:
+        env.close()
+
+    elapsed = time.perf_counter() - t0
+    log.info(
+        "Ligand preprocessing: %d computed, %d failed in %.1fs (%.0f/s)",
+        computed, failed_count, elapsed, computed / elapsed if elapsed > 0 else 0,
+    )
+    return lmdb_path, hits, computed
+
+
+def _lmdb_batch_get(lmdb_path: Path, keys: list[str]) -> dict[str, dict[str, Any]]:
+    """Batch-read post-transformed ligand features from LMDB.
+
+    Values are deserialized via torch.load(weights_only=True).
+    """
+    import lmdb
+    env = lmdb.open(str(lmdb_path), readonly=True, lock=False)
+    try:
+        result: dict[str, dict[str, Any]] = {}
+        with env.begin() as txn:
+            for key in keys:
+                raw = txn.get(key.encode("utf-8"))
+                if raw is not None:
+                    result[key] = torch.load(
+                        io.BytesIO(raw), weights_only=True, map_location="cpu",
+                    )
+    finally:
+        env.close()
+    return result
+
+
+def precompute_ligands_memory(
+    canonical_smiles_set: set[str],
+    num_workers: int,
+) -> dict[str, dict[str, Any]]:
+    """In-memory ligand featurization (no LMDB). For small runs or --no-ligand-cache."""
+    if len(canonical_smiles_set) > 50_000:
+        raise ValueError(
+            f"--no-ligand-cache with {len(canonical_smiles_set)} unique ligands exceeds "
+            f"50K limit. Remove --no-ligand-cache to use LMDB caching."
+        )
+
+    smiles_list = list(canonical_smiles_set)
+    if num_workers <= 0:
+        num_workers = max(1, (os.cpu_count() or 1) - 2)
+
+    log.info("Computing %d ligand features in-memory (%d workers)...", len(smiles_list), num_workers)
+
+    chunks = [smiles_list[i:i + MP_CHUNK_SIZE] for i in range(0, len(smiles_list), MP_CHUNK_SIZE)]
+    result: dict[str, dict[str, Any]] = {}
+    failed_count = 0
+    t0 = time.perf_counter()
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        futures = {executor.submit(_process_ligand_chunk, chunk): i for i, chunk in enumerate(chunks)}
+        for future in as_completed(futures):
+            for csmi, feat_bytes, error in future.result():
+                if error is not None:
+                    failed_count += 1
+                else:
+                    result[csmi] = torch.load(
+                        io.BytesIO(feat_bytes), weights_only=True, map_location="cpu",
+                    )
+
+    elapsed = time.perf_counter() - t0
+    log.info(
+        "In-memory ligand features: %d OK, %d failed in %.1fs",
+        len(result), failed_count, elapsed,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def load_model(model_name: str, device: torch.device) -> torch.nn.Module:
+    """Load PSICHIC model with pretrained weights.
+
+    Args:
+        model_name: one of 'PDBv2020_PSICHIC' or 'multitask_PSICHIC'
+        device: CUDA device
+    """
+    from psichic_model import PSICHIC  # noqa: E402
+
+    weights_dir = REPO_ROOT / "trained_weights" / model_name
+
+    with open(weights_dir / "config.json") as f:
+        config = json.load(f)
+    degree_dict = torch.load(
+        weights_dir / "degree.pt", map_location="cpu", weights_only=True,
+    )
+    params = config["params"]
+    tasks = config["tasks"]
+    model = PSICHIC(
+        mol_deg=degree_dict["ligand_deg"],
+        prot_deg=degree_dict["protein_deg"],
+        mol_in_channels=params["mol_in_channels"],
+        prot_in_channels=params["prot_in_channels"],
+        prot_evo_channels=params["prot_evo_channels"],
+        hidden_channels=params["hidden_channels"],
+        pre_layers=params["pre_layers"],
+        post_layers=params["post_layers"],
+        aggregators=params["aggregators"],
+        scalers=params["scalers"],
+        total_layer=params["total_layer"],
+        K=params["K"],
+        heads=params["heads"],
+        dropout=params["dropout"],
+        dropout_attn_score=params["dropout_attn_score"],
+        regression_head=tasks["regression_task"],
+        classification_head=tasks["classification_task"],
+        multiclassification_head=tasks["mclassification_task"],
+        device=device,
+    ).to(device)
+
+    state_dict = torch.load(
+        weights_dir / "model.pt", map_location="cpu", weights_only=True,
+    )
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    log.info(
+        "PSICHIC model '%s' loaded (%.1fM params, tasks: reg=%s cls=%s mcls=%s)",
+        model_name,
+        sum(p.numel() for p in model.parameters()) / 1e6,
+        tasks["regression_task"],
+        tasks["classification_task"],
+        tasks["mclassification_task"],
+    )
+    return model
+
+
+def _model_has_classification(model_name: str) -> tuple[bool, bool]:
+    """Check if model has classification/multiclassification heads."""
+    weights_dir = REPO_ROOT / "trained_weights" / model_name
+    with open(weights_dir / "config.json") as f:
+        config = json.load(f)
+    tasks = config["tasks"]
+    has_cls = bool(tasks.get("classification_task", False))
+    has_mcls = bool(tasks.get("mclassification_task", 0))
+    return has_cls, has_mcls
+
+
+# ---------------------------------------------------------------------------
+# Pair building + Data object construction
+# ---------------------------------------------------------------------------
+
+
+def build_data_object(mol: dict, prot: dict) -> MultiGraphData:
+    """Build a single MultiGraphData object from preprocessed mol/prot dicts."""
+    return MultiGraphData(
+        mol_x=mol["atom_idx"],
+        mol_x_feat=mol["atom_feature"],
+        mol_edge_index=mol["atom_edge_index"],
+        mol_edge_attr=mol["atom_edge_attr"],
+        mol_num_nodes=mol["atom_num_nodes"],
+        clique_x=mol["x_clique"],
+        clique_edge_index=mol["tree_edge_index"],
+        atom2clique_index=mol["atom2clique_index"],
+        clique_num_nodes=mol["clique_num_nodes"],
+        prot_node_aa=prot["seq_feat"],
+        prot_node_evo=prot["token_representation"],
+        prot_node_pos=prot["node_pos"],
+        prot_seq=prot["seq"],
+        prot_edge_index=prot["edge_index"],
+        prot_edge_weight=prot["edge_weight"],
+        prot_num_nodes=prot["num_nodes"],
+        reg_y=None,
+        cls_y=None,
+        mcls_y=None,
+        mol_key="",
+        prot_key="",
+    )
+
+
+def _run_forward(
+    model: torch.nn.Module,
+    batch: Batch,
+    use_amp: bool,
+    save_cluster: bool = False,
+) -> tuple:
+    """Run model forward on a batch. Returns (reg_pred, cls_pred, mcls_pred, attention_dict)."""
+    kwargs = dict(
+        mol_x=batch.mol_x,
+        mol_x_feat=batch.mol_x_feat,
+        bond_x=batch.mol_edge_attr,
+        atom_edge_index=batch.mol_edge_index,
+        clique_x=batch.clique_x,
+        clique_edge_index=batch.clique_edge_index,
+        atom2clique_index=batch.atom2clique_index,
+        residue_x=batch.prot_node_aa,
+        residue_evo_x=batch.prot_node_evo,
+        residue_edge_index=batch.prot_edge_index,
+        residue_edge_weight=batch.prot_edge_weight,
+        mol_batch=batch.mol_x_batch,
+        prot_batch=batch.prot_node_aa_batch,
+        clique_batch=batch.clique_x_batch,
+        save_cluster=save_cluster,
+    )
+
+    if use_amp:
+        with torch.amp.autocast(device_type="cuda"):
+            reg_pred, cls_pred, mcls_pred, _sp, _o, _cl, attention_dict = model(**kwargs)
+    else:
+        reg_pred, cls_pred, mcls_pred, _sp, _o, _cl, attention_dict = model(**kwargs)
+
+    return reg_pred, cls_pred, mcls_pred, attention_dict
+
+
+# ---------------------------------------------------------------------------
+# Streaming screening
+# ---------------------------------------------------------------------------
+
+
+def _safe_protein_id(protein_id: str) -> str:
+    """Sanitize protein_id for filesystem use."""
+    safe = re.sub(r'[/\\:*?"<>|]', "_", protein_id)
+    # Re-check after substitution: ".." cannot survive the regex above (/ and \
+    # are replaced), but guard anyway for clarity.
+    if ".." in safe:
+        raise ValueError(f"Unsafe protein_id (contains '..'): {protein_id!r}")
+    # Reject names that resolve to the current or parent directory.
+    if not safe or safe.strip(".") == "":
+        raise ValueError(f"Unsafe protein_id (resolves to dot path): {protein_id!r}")
+    return safe
+
+
+def _smiles_hash(smiles: str) -> str:
+    """SHA-256 hash of SMILES string (for pair_id construction)."""
+    return hashlib.sha256(smiles.encode("utf-8")).hexdigest()
+
+
+def screen_streaming_topk(
+    model: torch.nn.Module,
+    protein_features: dict[str, dict],
+    proteins: dict[str, str],
+    canonical_map: dict[str, str],
+    valid_smiles: list[str],
+    lmdb_path: Path | None,
+    memory_ligands: dict[str, dict[str, Any]] | None,
+    top_k: int,
+    batch_size: int,
+    use_amp: bool,
+    has_cls: bool,
+    has_mcls: bool,
+    device: torch.device,
+) -> dict[str, list[tuple[float, str, float | None, tuple[float, ...] | None]]]:
+    """Stream scoring with per-protein top-K heaps.
+
+    Returns:
+        heaps: {protein_id: [(neg_score, original_smiles, cls_pred, mcls_pred_tuple)]}
+        Heap entries use negative scores for max-heap via heapq (min-heap).
+    """
+    num_proteins = len(proteins)
+    num_ligands = len(valid_smiles)
+    total_pairs = num_proteins * num_ligands
+    log.info(
+        "Streaming top-%d: %d proteins x %d ligands = %d pairs",
+        top_k, num_proteins, num_ligands, total_pairs,
+    )
+
+    # Per-protein min-heaps. Entries: (score, counter, orig_smi, cls_val, mcls_val).
+    # Counter is a monotonic tiebreaker so heapq never compares heterogeneous
+    # cls_val/mcls_val fields (float vs None) when scores tie.
+    heaps: dict[str, list] = {pid: [] for pid in proteins}
+    heap_counter = itertools.count()
+    scored = 0
+    t0 = time.perf_counter()
+
+    with torch.inference_mode():
+        for chunk_start in range(0, num_ligands, LIGAND_CHUNK_SIZE):
+            chunk_smiles = valid_smiles[chunk_start:chunk_start + LIGAND_CHUNK_SIZE]
+
+            # Get canonical SMILES for this chunk
+            chunk_canonical = [canonical_map[s] for s in chunk_smiles]
+            unique_canonical_in_chunk = list(set(chunk_canonical))
+
+            # Load ligand features for this chunk
+            if lmdb_path is not None:
+                chunk_ligands = _lmdb_batch_get(lmdb_path, unique_canonical_in_chunk)
+            else:
+                chunk_ligands = {}
+                for k in unique_canonical_in_chunk:
+                    if k in memory_ligands:
+                        chunk_ligands[k] = memory_ligands[k]
+                    else:
+                        log.warning("Canonical SMILES missing from memory cache: %s", k)
+
+            # Build pairs lazily — avoid materializing the full protein × ligand
+            # cross-product in memory (would be num_proteins × chunk_size tuples).
+            pair_iter = (
+                (prot_id, prot_seq, can_smi, orig_smi)
+                for prot_id, prot_seq in proteins.items()
+                for orig_smi, can_smi in zip(chunk_smiles, chunk_canonical)
+                if can_smi in chunk_ligands
+            )
+
+            # Score in batches (consume generator incrementally)
+            for batch_pairs in _batch_iter(pair_iter, batch_size):
+                data_objects: list[MultiGraphData] = []
+                for _pid, prot_seq, can_smi, _orig_smi in batch_pairs:
+                    prot = protein_features[prot_seq]
+                    mol = chunk_ligands[can_smi]
+                    data_objects.append(build_data_object(mol, prot))
+
+                batch = Batch.from_data_list(
+                    data_objects,
+                    follow_batch=["mol_x", "clique_x", "prot_node_aa"],
+                ).to(device)
+
+                reg_pred, cls_pred, mcls_pred, _ = _run_forward(
+                    model, batch, use_amp, save_cluster=False,
+                )
+
+                # Extract predictions (atleast_1d guards against squeeze on batch_size=1)
+                if reg_pred is not None:
+                    reg_np = np.atleast_1d(reg_pred.squeeze().detach().cpu().float().numpy())
+                else:
+                    reg_np = np.zeros(len(batch_pairs))
+
+                cls_np = None
+                if cls_pred is not None and has_cls:
+                    cls_np = np.atleast_1d(torch.sigmoid(cls_pred).squeeze().detach().cpu().float().numpy())
+
+                mcls_np = None
+                if mcls_pred is not None and has_mcls:
+                    mcls_np = torch.softmax(mcls_pred, dim=-1).detach().cpu().float().numpy()
+
+                # Update heaps
+                for i, (prot_id, _seq, _csmi, orig_smi) in enumerate(batch_pairs):
+                    score = float(reg_np[i])
+                    cls_val = float(cls_np[i]) if cls_np is not None else None
+                    mcls_val = tuple(mcls_np[i].tolist()) if mcls_np is not None else None
+
+                    heap = heaps[prot_id]
+                    entry = (score, next(heap_counter), orig_smi, cls_val, mcls_val)
+                    if len(heap) < top_k:
+                        heapq.heappush(heap, entry)
+                    elif score > heap[0][0]:
+                        heapq.heapreplace(heap, entry)
+
+                scored += len(batch_pairs)
+
+            # Progress per chunk
+            elapsed = time.perf_counter() - t0
+            rate = scored / elapsed if elapsed > 0 else 0
+            log.info(
+                "  Scored %d / %d pairs (%.0f pairs/s)",
+                scored, total_pairs, rate,
+            )
+
+    total_time = time.perf_counter() - t0
+    log.info(
+        "Streaming complete: %d pairs in %.1fs (%.0f pairs/s)",
+        scored, total_time, scored / total_time if total_time > 0 else 0,
+    )
+    return heaps
+
+
+def screen_all(
+    model: torch.nn.Module,
+    protein_features: dict[str, dict],
+    proteins: dict[str, str],
+    canonical_map: dict[str, str],
+    valid_smiles: list[str],
+    lmdb_path: Path | None,
+    memory_ligands: dict[str, dict[str, Any]] | None,
+    batch_size: int,
+    use_amp: bool,
+    has_cls: bool,
+    has_mcls: bool,
+    device: torch.device,
+    output_path: Path,
+) -> int:
+    """Score all pairs, write results to CSV as we go. For ≤10M pairs without --top-k.
+
+    Returns total rows written.
+    """
+    num_proteins = len(proteins)
+    num_ligands = len(valid_smiles)
+    total_pairs = num_proteins * num_ligands
+
+    log.info("Scoring all %d pairs (streaming to CSV)...", total_pairs)
+
+    # Determine CSV columns
+    fieldnames = ["protein_id", "smiles", "prediction", "protein_length"]
+    if has_cls:
+        fieldnames.append("predicted_binary_interaction")
+    if has_mcls:
+        fieldnames.extend(["predicted_agonist", "predicted_antagonist", "predicted_nonbinder"])
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    scored = 0
+    t0 = time.perf_counter()
+
+    with open(output_path, "w", newline="") as fh, torch.inference_mode():
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for chunk_start in range(0, num_ligands, LIGAND_CHUNK_SIZE):
+            chunk_smiles = valid_smiles[chunk_start:chunk_start + LIGAND_CHUNK_SIZE]
+            chunk_canonical = [canonical_map[s] for s in chunk_smiles]
+            unique_canonical_in_chunk = list(set(chunk_canonical))
+
+            if lmdb_path is not None:
+                chunk_ligands = _lmdb_batch_get(lmdb_path, unique_canonical_in_chunk)
+            else:
+                chunk_ligands = {}
+                for k in unique_canonical_in_chunk:
+                    if k in memory_ligands:
+                        chunk_ligands[k] = memory_ligands[k]
+                    else:
+                        log.warning("Canonical SMILES missing from memory cache: %s", k)
+
+            # Build pairs lazily (same as screen_streaming_topk)
+            pair_iter = (
+                (prot_id, prot_seq, can_smi, orig_smi)
+                for prot_id, prot_seq in proteins.items()
+                for orig_smi, can_smi in zip(chunk_smiles, chunk_canonical)
+                if can_smi in chunk_ligands
+            )
+
+            for batch_pairs in _batch_iter(pair_iter, batch_size):
+                data_objects = []
+                for _pid, prot_seq, can_smi, _orig_smi in batch_pairs:
+                    prot = protein_features[prot_seq]
+                    mol = chunk_ligands[can_smi]
+                    data_objects.append(build_data_object(mol, prot))
+
+                batch = Batch.from_data_list(
+                    data_objects,
+                    follow_batch=["mol_x", "clique_x", "prot_node_aa"],
+                ).to(device)
+
+                reg_pred, cls_pred, mcls_pred, _ = _run_forward(
+                    model, batch, use_amp, save_cluster=False,
+                )
+
+                reg_np = np.atleast_1d(reg_pred.squeeze().detach().cpu().float().numpy()) if reg_pred is not None else np.zeros(len(batch_pairs))
+
+                cls_np = None
+                if cls_pred is not None and has_cls:
+                    cls_np = np.atleast_1d(torch.sigmoid(cls_pred).squeeze().detach().cpu().float().numpy())
+
+                mcls_np = None
+                if mcls_pred is not None and has_mcls:
+                    mcls_np = torch.softmax(mcls_pred, dim=-1).detach().cpu().float().numpy()
+
+                for i, (prot_id, prot_seq, _csmi, orig_smi) in enumerate(batch_pairs):
+                    row: dict[str, Any] = {
+                        "protein_id": prot_id,
+                        "smiles": orig_smi,
+                        "prediction": round(float(reg_np[i]), 4),
+                        "protein_length": len(prot_seq),
+                    }
+                    if has_cls and cls_np is not None:
+                        row["predicted_binary_interaction"] = round(float(cls_np[i]), 4)
+                    if has_mcls and mcls_np is not None:
+                        # softmax order: [antagonist, nonbinder, agonist] per screening.py
+                        row["predicted_agonist"] = round(float(mcls_np[i][2]), 4)
+                        row["predicted_antagonist"] = round(float(mcls_np[i][0]), 4)
+                        row["predicted_nonbinder"] = round(float(mcls_np[i][1]), 4)
+                    writer.writerow(row)
+
+                scored += len(batch_pairs)
+
+            elapsed = time.perf_counter() - t0
+            rate = scored / elapsed if elapsed > 0 else 0
+            log.info("  Scored %d / %d pairs (%.0f pairs/s)", scored, total_pairs, rate)
+
+    total_time = time.perf_counter() - t0
+    log.info(
+        "Scoring complete: %d pairs in %.1fs (%.0f pairs/s)",
+        scored, total_time, scored / total_time if total_time > 0 else 0,
+    )
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Interpretation outputs
+# ---------------------------------------------------------------------------
+
+
+def _unbatch_nodes(data_tensor: torch.Tensor, index_tensor: torch.Tensor) -> list[torch.Tensor]:
+    """Unbatch a data tensor based on a batch index tensor."""
+    return [data_tensor[index_tensor == i] for i in index_tensor.unique()]
+
+
+def _minmax_norm(arr: np.ndarray) -> np.ndarray:
+    """Min-max normalize. Returns zeros if span is zero."""
+    span = arr.max() - arr.min()
+    if span == 0:
+        return np.zeros_like(arr)
+    return (arr - arr.min()) / span
+
+
+def _percentile_rank(arr: np.ndarray) -> np.ndarray:
+    """Percentile rank within array. Returns [1.0] for single-element."""
+    if len(arr) <= 1:
+        return np.ones_like(arr)
+    return np.argsort(np.argsort(arr)) / (len(arr) - 1)
+
+
+def write_interpretation(
+    model: torch.nn.Module,
+    protein_features: dict[str, dict],
+    proteins: dict[str, str],
+    canonical_map: dict[str, str],
+    lmdb_path: Path | None,
+    memory_ligands: dict[str, dict[str, Any]] | None,
+    heaps: dict[str, list],
+    batch_size: int,
+    use_amp: bool,
+    interpret_dir: Path,
+    device: torch.device,
+) -> None:
+    """Re-run model on top-K pairs with save_cluster=True and write interpretation CSVs."""
+    import pandas as pd
+
+    # Collect all top-K pairs to re-score
+    interpret_pairs: list[tuple[str, str, str]] = []  # (prot_id, prot_seq, original_smiles)
+    for prot_id, heap in heaps.items():
+        prot_seq = proteins[prot_id]
+        for _score, _counter, orig_smi, _cls, _mcls in heap:
+            interpret_pairs.append((prot_id, prot_seq, orig_smi))
+
+    if not interpret_pairs:
+        log.info("No pairs to interpret")
+        return
+
+    log.info("Running interpretation pass on %d top-K pairs...", len(interpret_pairs))
+
+    # Collect all needed canonical SMILES
+    needed_canonical = set()
+    for _pid, _seq, orig_smi in interpret_pairs:
+        if orig_smi in canonical_map:
+            needed_canonical.add(canonical_map[orig_smi])
+
+    if lmdb_path is not None:
+        ligand_features = _lmdb_batch_get(lmdb_path, list(needed_canonical))
+    else:
+        ligand_features = {}
+        for k in needed_canonical:
+            if k in memory_ligands:
+                ligand_features[k] = memory_ligands[k]
+            else:
+                log.warning("Canonical SMILES missing from memory cache: %s", k)
+
+    interpret_dir.mkdir(parents=True, exist_ok=True)
+
+    with torch.inference_mode():
+        for batch_start in range(0, len(interpret_pairs), batch_size):
+            batch_pairs = interpret_pairs[batch_start:batch_start + batch_size]
+
+            data_objects = []
+            valid_batch_pairs = []
+            for _pid, prot_seq, orig_smi in batch_pairs:
+                can_smi = canonical_map.get(orig_smi)
+                if can_smi is None:
+                    log.warning("Missing canonical mapping for %s — skipping", orig_smi)
+                    continue
+                mol = ligand_features.get(can_smi)
+                if mol is None:
+                    log.warning("Missing ligand features for %s — skipping", orig_smi)
+                    continue
+                prot = protein_features[prot_seq]
+                data_objects.append(build_data_object(mol, prot))
+                valid_batch_pairs.append((_pid, prot_seq, orig_smi))
+
+            if not data_objects:
+                continue
+
+            batch_pairs = valid_batch_pairs
+
+            batch = Batch.from_data_list(
+                data_objects,
+                follow_batch=["mol_x", "clique_x", "prot_node_aa"],
+            ).to(device)
+
+            _, _, _, attention_dict = _run_forward(
+                model, batch, use_amp, save_cluster=True,
+            )
+
+            # Extract per-pair interpretation
+            prot_batch_idx = attention_dict["protein_residue_index"]
+            residue_scores_unbatched = _unbatch_nodes(
+                attention_dict["residue_final_score"], prot_batch_idx,
+            )
+
+            # Cluster assignments (if available)
+            cluster_s0 = cluster_s1 = cluster_s2 = None
+            has_clusters = all(idx in attention_dict.get("cluster_s", {}) for idx in range(3))
+            if has_clusters:
+                cluster_s0 = _unbatch_nodes(
+                    attention_dict["cluster_s"][0].softmax(dim=-1), prot_batch_idx,
+                )
+                cluster_s1 = _unbatch_nodes(
+                    attention_dict["cluster_s"][1].softmax(dim=-1), prot_batch_idx,
+                )
+                cluster_s2 = _unbatch_nodes(
+                    attention_dict["cluster_s"][2].softmax(dim=-1), prot_batch_idx,
+                )
+
+            for i, (prot_id, _prot_seq, orig_smi) in enumerate(batch_pairs):
+                safe_pid = _safe_protein_id(prot_id)
+                pair_id = f"{safe_pid}__{_smiles_hash(orig_smi)}"
+                pair_dir = interpret_dir / safe_pid / pair_id
+                pair_dir.mkdir(parents=True, exist_ok=True)
+
+                # Residue scores
+                scores_np = residue_scores_unbatched[i].cpu().flatten().numpy()
+                normed = _minmax_norm(scores_np)
+                pctile = _percentile_rank(normed)
+
+                # Get protein sequence for residue types
+                prot_seq = _prot_seq
+                residue_types = list(prot_seq) if prot_seq else ["?"] * len(scores_np)
+
+                df_data: dict[str, Any] = {
+                    "Residue_ID": list(range(1, len(scores_np) + 1)),
+                    "Residue_Type": residue_types[:len(scores_np)],
+                    "PSICHIC_Residue_Score": normed,
+                    "PSICHIC_Residue_Percentile": pctile,
+                }
+
+                if has_clusters:
+                    s0 = cluster_s0[i].cpu().numpy()
+                    for ci in range(s0.shape[1]):
+                        df_data[f"Layer0_Cluster{ci}"] = s0[:, ci]
+
+                    s1 = cluster_s1[i].cpu().numpy()
+                    for ci in range(s1.shape[1]):
+                        df_data[f"Layer1_Cluster{ci}"] = s1[:, ci]
+
+                    s2 = cluster_s2[i].cpu().numpy()
+                    for ci in range(s2.shape[1]):
+                        df_data[f"Layer2_Cluster{ci}"] = s2[:, ci]
+
+                protein_df = pd.DataFrame(df_data)
+                protein_df.to_csv(pair_dir / "protein.csv", index=False)
+
+    log.info("Interpretation CSVs written to %s", interpret_dir)
+
+
+# ---------------------------------------------------------------------------
+# Output writing
+# ---------------------------------------------------------------------------
+
+
+def write_topk_csv(
+    heaps: dict[str, list],
+    proteins: dict[str, str],
+    has_cls: bool,
+    has_mcls: bool,
+    output_path: Path,
+) -> int:
+    """Write top-K results from heaps to sorted CSV.
+
+    Returns number of rows written.
+    """
+    fieldnames = ["protein_id", "smiles", "prediction", "protein_length"]
+    if has_cls:
+        fieldnames.append("predicted_binary_interaction")
+    if has_mcls:
+        fieldnames.extend(["predicted_agonist", "predicted_antagonist", "predicted_nonbinder"])
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    rows_written = 0
+
+    with open(output_path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for prot_id in sorted(proteins.keys()):
+            heap = heaps.get(prot_id, [])
+            # Sort descending by score
+            sorted_entries = sorted(heap, key=lambda e: -e[0])
+            prot_seq = proteins[prot_id]
+
+            for score, _counter, orig_smi, cls_val, mcls_val in sorted_entries:
+                row: dict[str, Any] = {
+                    "protein_id": prot_id,
+                    "smiles": orig_smi,
+                    "prediction": round(score, 4),
+                    "protein_length": len(prot_seq),
+                }
+                if has_cls and cls_val is not None:
+                    row["predicted_binary_interaction"] = round(cls_val, 4)
+                if has_mcls and mcls_val is not None:
+                    row["predicted_agonist"] = round(mcls_val[2], 4)
+                    row["predicted_antagonist"] = round(mcls_val[0], 4)
+                    row["predicted_nonbinder"] = round(mcls_val[1], 4)
+                writer.writerow(row)
+                rows_written += 1
+
+    return rows_written
+
+
+def sort_csv_by_score(output_path: Path) -> None:
+    """Sort an existing CSV by (protein_id asc, prediction desc)."""
+    import pandas as pd
+
+    df = pd.read_csv(output_path)
+    df = df.sort_values(
+        by=["protein_id", "prediction"],
+        ascending=[True, False],
+    ).reset_index(drop=True)
+    df.to_csv(output_path, index=False)
+    log.info("Sorted %d rows in %s", len(df), output_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="PSICHIC optimized screening pipeline",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--fasta", type=Path, required=True,
+        help="Path to FASTA file with protein sequences",
+    )
+    parser.add_argument(
+        "--smiles", type=Path, required=True,
+        help="Path to SMILES file (CSV, SMI, or tar.gz)",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=Path("screening_results.csv"),
+        help="Output CSV path (default: screening_results.csv)",
+    )
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--amp", action="store_true", default=True, help="Enable AMP (default: on)")
+    parser.add_argument("--no-amp", action="store_false", dest="amp", help="Disable AMP")
+    parser.add_argument(
+        "--cache-dir", type=Path, default=DEFAULT_PROTEIN_CACHE_DIR,
+        help="Protein embedding cache directory",
+    )
+    parser.add_argument("--no-cache", action="store_true", help="Disable protein cache")
+    parser.add_argument("--device", default="cuda:0", help="CUDA device")
+    parser.add_argument(
+        "--top-k", type=int, default=None,
+        help="Only output top-K predictions per protein (required for >10M pairs)",
+    )
+    # Ligand cache flags
+    parser.add_argument(
+        "--ligand-cache-dir", type=Path, default=DEFAULT_LIGAND_CACHE_DIR,
+        help="LMDB ligand cache directory (default: cache/)",
+    )
+    parser.add_argument(
+        "--no-ligand-cache", action="store_true",
+        help="Skip LMDB, hold ligands in memory (max 50K unique ligands)",
+    )
+    parser.add_argument(
+        "--ligand-workers", type=int, default=0,
+        help="Number of ligand featurization workers (0=auto, uses all cores minus 2)",
+    )
+    # Interpretation flags
+    parser.add_argument(
+        "--save-interpret", action="store_true",
+        help="Save per-residue interpretation CSVs (requires --top-k)",
+    )
+    parser.add_argument(
+        "--interpret-dir", type=Path, default=Path("interpretation_results"),
+        help="Directory for interpretation outputs",
+    )
+    # Model selection
+    parser.add_argument(
+        "--model", default="PDBv2020_PSICHIC",
+        choices=["PDBv2020_PSICHIC", "multitask_PSICHIC"],
+        help="Model weights to use (default: PDBv2020_PSICHIC)",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    # Set spawn start method before any ProcessPoolExecutor is created.
+    # Must be inside main() to avoid side effects when inference.py is imported as a library.
+    if multiprocessing.get_start_method(allow_none=True) is None:
+        multiprocessing.set_start_method("spawn")
+
+    args = parse_args()
+
+    # Validate flag combinations
+    if args.save_interpret and args.top_k is None:
+        log.error("--save-interpret requires --top-k to limit output volume")
+        sys.exit(1)
+
+    # Determine model capabilities
+    has_cls, has_mcls = _model_has_classification(args.model)
+
+    t_total = time.perf_counter()
+
+    # ---------------------------------------------------------------
+    # STEP 1: Parse inputs (CPU — no CUDA yet)
+    # ---------------------------------------------------------------
+    log.info("=" * 60)
+    log.info("STEP 1: Parsing inputs")
+    proteins = parse_fasta(args.fasta)
+    smiles_list = parse_smiles(args.smiles)
+
+    if not proteins:
+        log.error("No proteins found in %s", args.fasta)
+        sys.exit(1)
+    if not smiles_list:
+        log.error("No SMILES found in %s", args.smiles)
+        sys.exit(1)
+
+    # Build canonical mapping
+    canonical_map, failed_smiles = _build_canonical_map(smiles_list)
+    valid_smiles = [s for s in smiles_list if s in canonical_map]
+    unique_canonical = set(canonical_map.values())
+
+    total_pairs = len(proteins) * len(valid_smiles)
+    log.info(
+        "Screening matrix: %d proteins x %d ligands = %d pairs",
+        len(proteins), len(valid_smiles), total_pairs,
+    )
+
+    # Scale guard
+    if total_pairs > MAX_PAIRS_WITHOUT_TOPK and args.top_k is None:
+        log.error(
+            "Screening %d pairs (>%dM) without --top-k. "
+            "Use --top-k N to limit output volume (e.g. --top-k 100).",
+            total_pairs, MAX_PAIRS_WITHOUT_TOPK // 1_000_000,
+        )
+        sys.exit(1)
+
+    # ---------------------------------------------------------------
+    # STEP 2: Precompute ligand features (CPU, multiprocessing — BEFORE CUDA)
+    # ---------------------------------------------------------------
+    log.info("=" * 60)
+    log.info("STEP 2: Precomputing ligand features")
+
+    lmdb_path: Path | None = None
+    memory_ligands: dict[str, dict[str, Any]] | None = None
+    num_workers = args.ligand_workers if args.ligand_workers > 0 else max(1, (os.cpu_count() or 1) - 2)
+
+    if args.no_ligand_cache:
+        memory_ligands = precompute_ligands_memory(unique_canonical, num_workers)
+    else:
+        lmdb_path, _hits, _computed = precompute_ligands_lmdb(
+            unique_canonical, args.ligand_cache_dir, num_workers,
+        )
+
+    # ---------------------------------------------------------------
+    # STEP 3: Precompute protein embeddings (CUDA — ESM-2)
+    # ---------------------------------------------------------------
+    log.info("=" * 60)
+    log.info("STEP 3: Precomputing protein embeddings (batched ESM-2)")
+    device = torch.device(args.device)
+    protein_cache_dir = None if args.no_cache else args.cache_dir
+    protein_features = precompute_proteins(proteins, device, protein_cache_dir)
+
+    missing_prots = [pid for pid, seq in proteins.items() if seq not in protein_features]
+    if missing_prots:
+        log.error("Failed to process proteins: %s", missing_prots)
+        sys.exit(1)
+
+    # ---------------------------------------------------------------
+    # STEP 4: Load PSICHIC model
+    # ---------------------------------------------------------------
+    log.info("=" * 60)
+    log.info("STEP 4: Loading PSICHIC model (%s)", args.model)
+    model = load_model(args.model, device)
+
+    # ---------------------------------------------------------------
+    # STEP 5: Screening
+    # ---------------------------------------------------------------
+    log.info("=" * 60)
+
+    if args.top_k is not None:
+        # Top-K streaming mode
+        log.info("STEP 5: Streaming top-%d scoring", args.top_k)
+        heaps = screen_streaming_topk(
+            model=model,
+            protein_features=protein_features,
+            proteins=proteins,
+            canonical_map=canonical_map,
+            valid_smiles=valid_smiles,
+            lmdb_path=lmdb_path,
+            memory_ligands=memory_ligands,
+            top_k=args.top_k,
+            batch_size=args.batch_size,
+            use_amp=args.amp,
+            has_cls=has_cls,
+            has_mcls=has_mcls,
+            device=device,
+        )
+
+        # Write top-K CSV
+        log.info("STEP 6: Writing top-%d results to %s", args.top_k, args.output)
+        rows_written = write_topk_csv(heaps, proteins, has_cls, has_mcls, args.output)
+
+        # Optional interpretation pass
+        if args.save_interpret:
+            log.info("STEP 7: Running interpretation pass")
+            write_interpretation(
+                model=model,
+                protein_features=protein_features,
+                proteins=proteins,
+                canonical_map=canonical_map,
+                lmdb_path=lmdb_path,
+                memory_ligands=memory_ligands,
+                heaps=heaps,
+                batch_size=args.batch_size,
+                use_amp=args.amp,
+                interpret_dir=args.interpret_dir,
+                device=device,
+            )
+    else:
+        # Full scoring mode (≤10M pairs)
+        log.info("STEP 5: Scoring all pairs (streaming to CSV)")
+        rows_written = screen_all(
+            model=model,
+            protein_features=protein_features,
+            proteins=proteins,
+            canonical_map=canonical_map,
+            valid_smiles=valid_smiles,
+            lmdb_path=lmdb_path,
+            memory_ligands=memory_ligands,
+            batch_size=args.batch_size,
+            use_amp=args.amp,
+            has_cls=has_cls,
+            has_mcls=has_mcls,
+            device=device,
+            output_path=args.output,
+        )
+        # Sort the CSV
+        log.info("STEP 6: Sorting results")
+        sort_csv_by_score(args.output)
+
+    # ---------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------
+    total_time = time.perf_counter() - t_total
+    log.info("=" * 60)
+    log.info("DONE: %d results written to %s", rows_written, args.output)
+    log.info("Total wall time: %.1fs", total_time)
+    if torch.cuda.is_available():
+        log.info(
+            "Peak GPU memory: %.1f GB",
+            torch.cuda.max_memory_allocated(device) / (1024**3),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/PSICHIC-prod/psichic_model.py
+++ b/PSICHIC-prod/psichic_model.py
@@ -1,0 +1,1183 @@
+"""PSICHIC model — consolidated single-file implementation.
+
+Functionally identical to PSICHIC/models/{net,layers,pna,scaler,drug_pool,protein_pool}.py.
+All class/attribute names preserved for state_dict compatibility with pretrained weights.
+
+Verify idempotency with: python verify_model.py
+"""
+
+import math
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+from torch_geometric.nn import global_add_pool
+from torch_geometric.nn.aggr import Aggregation, MultiAggregation
+from torch_geometric.nn.conv import GCNConv, MessagePassing
+from torch_geometric.nn.dense.linear import Linear as PyGLinear
+from torch_geometric.nn.inits import reset
+from torch_geometric.nn.norm import GraphNorm
+from torch_geometric.nn.resolver import (
+    activation_resolver,
+    aggregation_resolver as aggr_resolver,
+)
+from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils import (
+    degree,
+    softmax,
+    subgraph,
+    to_dense_adj,
+    to_dense_batch,
+)
+from torch_geometric.utils import scatter
+
+EPS = 1e-15
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (from scaler.py)
+# ---------------------------------------------------------------------------
+
+
+class DegreeScalerAggregation(Aggregation):
+    """PNA degree-scaler aggregation."""
+
+    def __init__(
+        self,
+        aggr: Union[str, List[str], Aggregation],
+        scaler: Union[str, List[str]],
+        deg: Tensor,
+        aggr_kwargs: Optional[List[Dict[str, Any]]] = None,
+    ):
+        super().__init__()
+        if isinstance(aggr, (str, Aggregation)):
+            self.aggr = aggr_resolver(aggr, **(aggr_kwargs or {}))
+        elif isinstance(aggr, (tuple, list)):
+            self.aggr = MultiAggregation(aggr, aggr_kwargs)
+        else:
+            raise ValueError(f"Invalid aggregation type: {type(aggr)}")
+
+        self.scaler = [scaler] if isinstance(aggr, str) else scaler
+        deg = deg.to(torch.float)
+        num_nodes = int(deg.sum())
+        bin_degrees = torch.arange(deg.numel(), device=deg.device)
+        self.avg_deg: Dict[str, float] = {
+            "lin": float((bin_degrees * deg).sum()) / num_nodes,
+            "log": float(((bin_degrees + 1).log() * deg).sum()) / num_nodes,
+            "exp": float((bin_degrees.exp() * deg).sum()) / num_nodes,
+        }
+
+    def forward(
+        self,
+        x: Tensor,
+        index: Optional[Tensor] = None,
+        ptr: Optional[Tensor] = None,
+        dim_size: Optional[int] = None,
+        dim: int = -2,
+    ) -> Tensor:
+        self.assert_index_present(index)
+        out = self.aggr(x, index, ptr, dim_size, dim)
+        assert index is not None
+        deg = degree(index, num_nodes=dim_size, dtype=out.dtype).clamp_(1)
+        size = [1] * len(out.size())
+        size[dim] = -1
+        deg = deg.view(size)
+
+        outs = []
+        for s in self.scaler:
+            if s == "identity":
+                outs.append(out)
+            elif s == "amplification":
+                outs.append(out * (torch.log(deg + 1) / self.avg_deg["log"]))
+            elif s == "attenuation":
+                outs.append(out * (self.avg_deg["log"] / torch.log(deg + 1)))
+            elif s == "exponential":
+                outs.append(out * (torch.exp(deg) / self.avg_deg["exp"]))
+            elif s == "linear":
+                outs.append(out * (deg / self.avg_deg["lin"]))
+            elif s == "inverse_linear":
+                outs.append(out * (self.avg_deg["lin"] / deg))
+            else:
+                raise ValueError(f"Unknown scaler '{s}'")
+        return torch.cat(outs, dim=-1) if len(outs) > 1 else outs[0]
+
+
+# ---------------------------------------------------------------------------
+# PNAConv (from pna.py)
+# ---------------------------------------------------------------------------
+
+
+class PNAConv(MessagePassing):
+    """Principal Neighbourhood Aggregation convolution."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        aggregators: List[str],
+        scalers: List[str],
+        deg: Tensor,
+        edge_dim: Optional[int] = None,
+        towers: int = 1,
+        pre_layers: int = 1,
+        post_layers: int = 1,
+        act: Union[str, Callable, None] = "relu",
+        act_kwargs: Optional[Dict[str, Any]] = None,
+        divide_input: bool = False,
+        **kwargs,
+    ):
+        aggr = DegreeScalerAggregation(aggregators, scalers, deg)
+        super().__init__(aggr=aggr, node_dim=0, **kwargs)
+
+        if divide_input:
+            assert in_channels % towers == 0
+        assert out_channels % towers == 0
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.edge_dim = edge_dim
+        self.towers = towers
+        self.divide_input = divide_input
+        self.F_in = in_channels // towers if divide_input else in_channels
+        self.F_out = out_channels // towers
+
+        if self.edge_dim is not None:
+            self.edge_encoder = PyGLinear(edge_dim, self.F_in)
+
+        self.pre_nns = nn.ModuleList()
+        self.post_nns = nn.ModuleList()
+        for _ in range(towers):
+            modules = [PyGLinear((3 if edge_dim else 2) * self.F_in, self.F_in)]
+            for _ in range(pre_layers - 1):
+                modules += [activation_resolver(act, **(act_kwargs or {}))]
+                modules += [PyGLinear(self.F_in, self.F_in)]
+            self.pre_nns.append(nn.Sequential(*modules))
+
+            in_ch = (len(aggregators) * len(scalers) + 1) * self.F_in
+            modules = [PyGLinear(in_ch, self.F_out)]
+            for _ in range(post_layers - 1):
+                modules += [activation_resolver(act, **(act_kwargs or {}))]
+                modules += [PyGLinear(self.F_out, self.F_out)]
+            self.post_nns.append(nn.Sequential(*modules))
+
+        self.lin = PyGLinear(out_channels, out_channels)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.edge_dim is not None:
+            self.edge_encoder.reset_parameters()
+        for n in self.pre_nns:
+            reset(n)
+        for n in self.post_nns:
+            reset(n)
+        self.lin.reset_parameters()
+
+    def forward(
+        self, x: Tensor, edge_index: Adj, edge_attr: OptTensor = None
+    ) -> Tensor:
+        if self.divide_input:
+            x = x.view(-1, self.towers, self.F_in)
+        else:
+            x = x.view(-1, 1, self.F_in).repeat(1, self.towers, 1)
+        out = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=None)
+        out = torch.cat([x, out], dim=-1)
+        outs = [nn(out[:, i]) for i, nn in enumerate(self.post_nns)]
+        out = torch.cat(outs, dim=1)
+        return self.lin(out)
+
+    def message(self, x_i: Tensor, x_j: Tensor, edge_attr: OptTensor) -> Tensor:
+        if edge_attr is not None:
+            edge_attr = self.edge_encoder(edge_attr)
+            edge_attr = edge_attr.view(-1, 1, self.F_in).repeat(1, self.towers, 1)
+            h = torch.cat([x_i, x_j, edge_attr], dim=-1)
+        else:
+            h = torch.cat([x_i, x_j], dim=-1)
+        return torch.stack([nn(h[:, i]) for i, nn in enumerate(self.pre_nns)], dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Helper modules (from layers.py)
+# ---------------------------------------------------------------------------
+
+
+class MLP(nn.Module):
+    """Multi-layer perceptron with optional input/output layer norm."""
+
+    def __init__(
+        self,
+        dims: List[int],
+        out_norm: bool = False,
+        in_norm: bool = False,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.FC_layers = nn.ModuleList(
+            [nn.Linear(dims[i - 1], dims[i], bias=bias) for i in range(1, len(dims))]
+        )
+        self.hidden_layers = len(dims) - 2
+        self.out_norm = out_norm
+        self.in_norm = in_norm
+        if self.out_norm:
+            self.out_ln = nn.LayerNorm(dims[-1])
+        if self.in_norm:
+            self.in_ln = nn.LayerNorm(dims[0])
+
+    def reset_parameters(self):
+        for layer in self.FC_layers:
+            layer.reset_parameters()
+        if self.out_norm:
+            self.out_ln.reset_parameters()
+        if self.in_norm:
+            self.in_ln.reset_parameters()
+
+    def forward(self, x: Tensor) -> Tensor:
+        y = self.in_ln(x) if self.in_norm else x
+        for i in range(self.hidden_layers):
+            y = F.relu(self.FC_layers[i](y))
+        y = self.FC_layers[-1](y)
+        if self.out_norm:
+            y = self.out_ln(y)
+        return y
+
+
+class PosLinear(nn.Module):
+    """Linear layer with positive weights (stored as log, applied as exp)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        init_value: float = 0.2,
+        device=None,
+        dtype=None,
+    ):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        weight = nn.init.uniform_(
+            torch.empty((out_features, in_features), **factory_kwargs),
+            a=init_value / 2,
+            b=init_value,
+        )
+        weight = torch.abs(weight)
+        self.weight = nn.Parameter(weight.log())
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.bias is not None:
+            nn.init.uniform_(self.bias)
+
+    def forward(self, input: Tensor) -> Tensor:
+        # Upcast to float32 before exp() to prevent fp16 overflow
+        w = self.weight.float().exp()
+        return F.linear(input, w.to(input.dtype), self.bias)
+
+
+class GCNCluster(nn.Module):
+    """Multi-layer GCN for cluster assignment."""
+
+    def __init__(
+        self, dims: List[int], out_norm: bool = False, in_norm: bool = False
+    ):
+        super().__init__()
+        self.Conv_layers = nn.ModuleList(
+            [GCNConv(dims[i - 1], dims[i]) for i in range(1, len(dims))]
+        )
+        self.hidden_layers = len(dims) - 2
+        self.out_norm = out_norm
+        self.in_norm = in_norm
+        if self.out_norm:
+            self.out_ln = nn.LayerNorm(dims[-1])
+        if self.in_norm:
+            self.in_ln = nn.LayerNorm(dims[0])
+
+    def reset_parameters(self):
+        for layer in self.Conv_layers:
+            layer.reset_parameters()
+        if self.out_norm:
+            self.out_ln.reset_parameters()
+        if self.in_norm:
+            self.in_ln.reset_parameters()
+
+    def forward(self, x: Tensor, edge_index: Tensor) -> Tensor:
+        y = self.in_ln(x) if self.in_norm else x
+        for i in range(self.hidden_layers):
+            y = F.relu(self.Conv_layers[i](y, edge_index))
+        y = self.Conv_layers[-1](y, edge_index)
+        if self.out_norm:
+            y = self.out_ln(y)
+        return y
+
+
+class Drug_PNAConv(nn.Module):
+    """PNA convolution for drug atom graphs with bond encoding."""
+
+    def __init__(
+        self,
+        mol_deg: Tensor,
+        hidden_channels: int,
+        edge_channels: int,
+        pre_layers: int = 2,
+        post_layers: int = 2,
+        aggregators: List[str] = None,
+        scalers: List[str] = None,
+        num_towers: int = 4,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        if aggregators is None:
+            aggregators = ["sum", "mean", "min", "max", "std"]
+        if scalers is None:
+            scalers = ["identity", "amplification", "attenuation"]
+
+        self.bond_encoder = nn.Embedding(5, hidden_channels)
+        self.atom_conv = PNAConv(
+            in_channels=hidden_channels,
+            out_channels=hidden_channels,
+            edge_dim=edge_channels,
+            aggregators=aggregators,
+            scalers=scalers,
+            deg=mol_deg,
+            pre_layers=pre_layers,
+            post_layers=post_layers,
+            towers=num_towers,
+            divide_input=True,
+        )
+        self.atom_norm = nn.LayerNorm(hidden_channels)
+        self.dropout = dropout
+
+    def reset_parameters(self):
+        self.atom_conv.reset_parameters()
+        self.atom_norm.reset_parameters()
+
+    def forward(
+        self, atom_x: Tensor, bond_x: Tensor, atom_edge_index: Tensor
+    ) -> Tensor:
+        bond_x = self.bond_encoder(bond_x.squeeze())
+        atom_x = atom_x + F.relu(
+            self.atom_norm(self.atom_conv(atom_x, atom_edge_index, bond_x))
+        )
+        atom_x = F.dropout(atom_x, self.dropout, training=self.training)
+        return atom_x
+
+
+class Protein_PNAConv(nn.Module):
+    """PNA convolution for protein residue graphs."""
+
+    def __init__(
+        self,
+        prot_deg: Tensor,
+        hidden_channels: int,
+        edge_channels: int,
+        pre_layers: int = 2,
+        post_layers: int = 2,
+        aggregators: List[str] = None,
+        scalers: List[str] = None,
+        num_towers: int = 4,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        if aggregators is None:
+            aggregators = ["sum", "mean", "min", "max", "std"]
+        if scalers is None:
+            scalers = ["identity", "amplification", "attenuation"]
+
+        self.conv = PNAConv(
+            in_channels=hidden_channels,
+            out_channels=hidden_channels,
+            edge_dim=edge_channels,
+            aggregators=aggregators,
+            scalers=scalers,
+            deg=prot_deg,
+            pre_layers=pre_layers,
+            post_layers=post_layers,
+            towers=num_towers,
+            divide_input=True,
+        )
+        self.norm = nn.LayerNorm(hidden_channels)
+        self.dropout = dropout
+
+    def reset_parameters(self):
+        self.conv.reset_parameters()
+        self.norm.reset_parameters()
+
+    def forward(
+        self, x: Tensor, prot_edge_index: Tensor, prot_edge_attr: Tensor
+    ) -> Tensor:
+        x = x + F.relu(self.norm(self.conv(x, prot_edge_index, prot_edge_attr)))
+        x = F.dropout(x, self.dropout, training=self.training)
+        return x
+
+
+class DrugProteinConv(MessagePassing):
+    """Cross-modal attention between drug cliques and protein clusters."""
+
+    _alpha: OptTensor
+
+    def __init__(
+        self,
+        atom_channels: int,
+        residue_channels: int,
+        heads: int = 1,
+        t: float = 0.2,
+        dropout_attn_score: float = 0.2,
+        edge_dim: Optional[int] = None,
+        **kwargs,
+    ):
+        kwargs.setdefault("aggr", "add")
+        super().__init__(node_dim=0, **kwargs)
+
+        assert residue_channels % heads == 0
+        assert atom_channels % heads == 0
+
+        self.residue_out_channels = residue_channels // heads
+        self.atom_out_channels = atom_channels // heads
+        self.heads = heads
+        self.edge_dim = edge_dim
+        self._alpha = None
+        self.t = t
+        self.dropout_attn_score = dropout_attn_score
+
+        H_a = heads * self.atom_out_channels
+        H_r = heads * self.residue_out_channels
+
+        # Protein → Drug attention
+        self.lin_key = nn.Linear(residue_channels, H_a, bias=False)
+        self.lin_query = nn.Linear(atom_channels, H_a, bias=False)
+        self.lin_value = nn.Linear(residue_channels, H_a, bias=False)
+        if edge_dim is not None:
+            self.lin_edge = nn.Linear(edge_dim, H_a, bias=False)
+        else:
+            self.lin_edge = self.register_parameter("lin_edge", None)
+
+        # Drug → Protein
+        self.lin_atom_value = nn.Linear(atom_channels, H_r, bias=False)
+
+        # Normalization
+        self.drug_in_norm = nn.LayerNorm(atom_channels)
+        self.residue_in_norm = nn.LayerNorm(residue_channels)
+        self.drug_out_norm = nn.LayerNorm(H_a)
+        self.residue_out_norm = nn.LayerNorm(H_r)
+
+        # MLP updates
+        self.clique_mlp = MLP(
+            [atom_channels * 2, atom_channels * 2, atom_channels], out_norm=True
+        )
+        self.residue_mlp = MLP(
+            [residue_channels * 2, residue_channels * 2, residue_channels], out_norm=True
+        )
+
+    def reset_parameters(self):
+        self.lin_key.reset_parameters()
+        self.lin_query.reset_parameters()
+        self.lin_value.reset_parameters()
+        if self.edge_dim:
+            self.lin_edge.reset_parameters()
+        self.lin_atom_value.reset_parameters()
+        self.drug_in_norm.reset_parameters()
+        self.residue_in_norm.reset_parameters()
+        self.drug_out_norm.reset_parameters()
+        self.residue_out_norm.reset_parameters()
+        self.clique_mlp.reset_parameters()
+        self.residue_mlp.reset_parameters()
+
+    def forward(
+        self,
+        drug_x: Tensor,
+        clique_x: Tensor,
+        clique_batch: Tensor,
+        residue_x: Tensor,
+        edge_index: Adj,
+    ):
+        H, aC = self.heads, self.atom_out_channels
+
+        # Protein residue → Drug atom
+        residue_hx = self.residue_in_norm(residue_x)
+        query = self.lin_query(drug_x).view(-1, H, aC)
+        key = self.lin_key(residue_hx).view(-1, H, aC)
+        value = self.lin_value(residue_hx).view(-1, H, aC)
+
+        drug_out = self.propagate(
+            edge_index, query=query, key=key, value=value, edge_attr=None, size=None
+        )
+        alpha = self._alpha
+        self._alpha = None
+
+        drug_out = drug_out.view(-1, H * aC)
+        drug_out = self.drug_out_norm(drug_out)
+        clique_out = torch.cat([clique_x, drug_out[clique_batch]], dim=-1)
+        clique_out = self.clique_mlp(clique_out)
+
+        # Drug atom → Protein residue
+        H, rC = self.heads, self.residue_out_channels
+        drug_hx = self.drug_in_norm(drug_x)
+        residue_value = self.lin_atom_value(drug_hx).view(-1, H, rC)[edge_index[1]]
+        residue_out = residue_value * alpha.view(-1, H, 1)
+        residue_out = residue_out.view(-1, H * rC)
+        residue_out = self.residue_out_norm(residue_out)
+        residue_out = torch.cat([residue_out, residue_x], dim=-1)
+        residue_out = self.residue_mlp(residue_out)
+
+        return clique_out, residue_out, (edge_index, alpha)
+
+    def message(
+        self,
+        query_i: Tensor,
+        key_j: Tensor,
+        value_j: Tensor,
+        edge_attr: OptTensor,
+        index: Tensor,
+        ptr: OptTensor,
+        size_i: Optional[int],
+    ) -> Tensor:
+        alpha = (query_i * key_j).sum(dim=-1) / math.sqrt(self.atom_out_channels)
+        alpha = alpha / self.t
+        alpha = F.dropout(alpha, p=self.dropout_attn_score, training=self.training)
+        alpha = softmax(alpha, index, ptr, size_i)
+        self._alpha = alpha
+        return value_j * alpha.view(-1, self.heads, 1)
+
+
+# ---------------------------------------------------------------------------
+# Drug pooling (from drug_pool.py)
+# ---------------------------------------------------------------------------
+
+
+class MotifPool(nn.Module):
+    """Multi-head motif-based drug pooling with attention scoring."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        heads: int,
+        dropout_attn_score: float = 0,
+        dropout_node_proba: float = 0,
+    ):
+        super().__init__()
+        assert hidden_dim % heads == 0
+
+        self.lin_proj = nn.Linear(hidden_dim, hidden_dim)
+        head_dim = hidden_dim // heads
+
+        self.score_proj = nn.ModuleList()
+        for _ in range(heads):
+            self.score_proj.append(MLP([head_dim, head_dim * 2, 1]))
+
+        self.heads = heads
+        self.hidden_dim = head_dim
+        self.dropout_node_proba = dropout_node_proba
+        self.dropout_attn_score = dropout_attn_score
+
+    def reset_parameters(self):
+        self.lin_proj.reset_parameters()
+        for m in self.score_proj:
+            m.reset_parameters()
+
+    def forward(
+        self,
+        x: Tensor,
+        x_clique: Tensor,
+        atom2clique_index: Tensor,
+        clique_batch: Tensor,
+        clique_edge_index: Tensor,
+    ):
+        row, col = atom2clique_index
+        H, C = self.heads, self.hidden_dim
+
+        hx_clique = scatter(
+            x[row], col, dim=0, dim_size=x_clique.size(0), reduce="mean"
+        )
+        x_clique = x_clique + F.relu(self.lin_proj(hx_clique))
+
+        score_clique = x_clique.view(-1, H, C)
+        score = torch.cat(
+            [mlp(score_clique[:, i]) for i, mlp in enumerate(self.score_proj)], dim=-1
+        )
+        score = F.dropout(score, p=self.dropout_attn_score, training=self.training)
+        alpha = softmax(score, clique_batch)
+
+        _, _, clique_drop_mask = _dropout_node(
+            clique_edge_index,
+            self.dropout_node_proba,
+            x_clique.size(0),
+            clique_batch,
+            self.training,
+        )
+        scaling_factor = 1.0 / (1.0 - self.dropout_node_proba)
+
+        drug_feat = x_clique.view(-1, H, C) * alpha.view(-1, H, 1)
+        drug_feat = drug_feat.view(-1, H * C) * clique_drop_mask.view(-1, 1)
+        drug_feat = global_add_pool(drug_feat, clique_batch) * scaling_factor
+
+        return drug_feat, x_clique, alpha
+
+
+# ---------------------------------------------------------------------------
+# Protein pooling (from protein_pool.py)
+# ---------------------------------------------------------------------------
+
+
+def _rank3_trace(x: Tensor) -> Tensor:
+    return torch.einsum("ijj->i", x)
+
+
+def _rank3_diag(x: Tensor) -> Tensor:
+    eye = torch.eye(x.size(1)).type_as(x)
+    return eye * x.unsqueeze(2).expand(*x.size(), x.size(1))
+
+
+def dense_mincut_pool(
+    x: Tensor,
+    adj: Tensor,
+    s: Tensor,
+    mask: Optional[Tensor] = None,
+    cluster_drop_node: Optional[Tensor] = None,
+):
+    """MinCut pooling: soft cluster assignment with spectral regularization."""
+    x = x.unsqueeze(0) if x.dim() == 2 else x
+    adj = adj.unsqueeze(0) if adj.dim() == 2 else adj
+    s = s.unsqueeze(0) if s.dim() == 2 else s
+
+    (batch_size, num_nodes, _), k = x.size(), s.size(-1)
+    s = torch.softmax(s, dim=-1)
+
+    if mask is not None:
+        s = s * mask.view(batch_size, num_nodes, 1).to(x.dtype)
+        x_mask = mask.view(batch_size, num_nodes, 1).to(x.dtype)
+        if cluster_drop_node is not None:
+            x_mask = cluster_drop_node.view(batch_size, num_nodes, 1).to(x.dtype)
+        x = x * x_mask
+
+    out = torch.matmul(s.transpose(1, 2), x)
+    out_adj = torch.matmul(torch.matmul(s.transpose(1, 2), adj), s)
+
+    # MinCut regularization
+    mincut_num = _rank3_trace(out_adj)
+    d_flat = torch.einsum("ijk->ij", adj)
+    d = _rank3_diag(d_flat)
+    mincut_den = _rank3_trace(torch.matmul(torch.matmul(s.transpose(1, 2), d), s))
+    mincut_loss = torch.mean(-(mincut_num / mincut_den))
+
+    # Orthogonality regularization
+    ss = torch.matmul(s.transpose(1, 2), s)
+    i_s = torch.eye(k).type_as(ss)
+    ortho_loss = torch.mean(
+        torch.norm(
+            ss / torch.norm(ss, dim=(-1, -2), keepdim=True) - i_s / torch.norm(i_s),
+            dim=(-1, -2),
+        )
+    )
+
+    # Normalize coarsened adjacency
+    ind = torch.arange(k, device=out_adj.device)
+    out_adj[:, ind, ind] = 0
+    d = torch.einsum("ijk->ij", out_adj)
+    d = torch.sqrt(d.float())[:, None] + EPS
+    out_adj = (out_adj / d) / d.transpose(1, 2)
+
+    return s, out, out_adj, mincut_loss, ortho_loss
+
+
+# ---------------------------------------------------------------------------
+# Utility functions (from layers.py / net.py)
+# ---------------------------------------------------------------------------
+
+
+def _unbatch(src: Tensor, batch: Tensor, dim: int = 0) -> Tuple:
+    """Split tensor by batch vector."""
+    sizes = degree(batch, dtype=torch.long).tolist()
+    return src.split(sizes, dim)
+
+
+def _dropout_edge(
+    edge_index: Tensor,
+    p: float = 0.5,
+    force_undirected: bool = False,
+    training: bool = True,
+) -> Tuple[Tensor, Tensor]:
+    """Randomly drop edges with probability p."""
+    if p < 0.0 or p > 1.0:
+        raise ValueError(f"Dropout probability must be in [0, 1], got {p}")
+    if not training or p == 0.0:
+        return edge_index, edge_index.new_ones(edge_index.size(1), dtype=torch.bool)
+
+    row, col = edge_index
+    edge_mask = torch.rand(row.size(0), device=edge_index.device) >= p
+    if force_undirected:
+        edge_mask[row > col] = False
+    edge_index = edge_index[:, edge_mask]
+    if force_undirected:
+        edge_index = torch.cat([edge_index, edge_index.flip(0)], dim=1)
+        edge_mask = edge_mask.nonzero().repeat((2, 1)).squeeze()
+    return edge_index, edge_mask
+
+
+def _dropout_node(
+    edge_index: Tensor,
+    p: float,
+    num_nodes: int,
+    batch: Tensor,
+    training: bool,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Randomly drop nodes, ensuring no graph is fully dropped."""
+    if p < 0.0 or p > 1.0:
+        raise ValueError(f"Dropout probability must be in [0, 1], got {p}")
+    if not training or p == 0.0:
+        node_mask = edge_index.new_ones(num_nodes, dtype=torch.bool)
+        edge_mask = edge_index.new_ones(edge_index.size(1), dtype=torch.bool)
+        return edge_index, edge_mask, node_mask
+
+    prob = torch.rand(num_nodes, device=edge_index.device)
+    node_mask = prob > p
+
+    batch_tf = global_add_pool(node_mask.view(-1, 1), batch).flatten()
+    unbatched = _unbatch(node_mask, batch)
+    parts = []
+    for has_nodes, sub_mask in zip(batch_tf, unbatched):
+        if has_nodes.item():
+            parts.append(sub_mask)
+        else:
+            idx = torch.randperm(sub_mask.size(0))[:1]
+            sub_mask[idx] = True
+            parts.append(sub_mask)
+    node_mask = torch.cat(parts)
+
+    edge_index, _, edge_mask = subgraph(
+        node_mask, edge_index, num_nodes=num_nodes, return_edge_mask=True
+    )
+    return edge_index, edge_mask, node_mask
+
+
+def _rbf(
+    D: Tensor,
+    D_min: float = 0.0,
+    D_max: float = 1.0,
+    D_count: int = 16,
+) -> Tensor:
+    """Radial basis function embedding of distances."""
+    D = torch.clamp(D, max=D_max)
+    D_mu = torch.linspace(D_min, D_max, D_count, device=D.device)
+    D_mu = D_mu.view([1, -1])
+    D_sigma = (D_max - D_min) / D_count
+    D_expand = torch.unsqueeze(D, -1)
+    return torch.exp(-((D_expand - D_mu) / D_sigma) ** 2)
+
+
+# ---------------------------------------------------------------------------
+# PSICHIC network (from net.py)
+# ---------------------------------------------------------------------------
+
+
+class PSICHIC(nn.Module):
+    """PSICHIC drug-protein interaction model.
+
+    Class renamed from `net` for clarity, but all submodule attribute names
+    are preserved for state_dict compatibility.
+    """
+
+    def __init__(
+        self,
+        mol_deg: Tensor,
+        prot_deg: Tensor,
+        mol_in_channels: int = 43,
+        prot_in_channels: int = 33,
+        prot_evo_channels: int = 1280,
+        hidden_channels: int = 200,
+        pre_layers: int = 2,
+        post_layers: int = 1,
+        aggregators: List[str] = None,
+        scalers: List[str] = None,
+        total_layer: int = 3,
+        K: Union[int, List[int]] = None,
+        t: float = 1,
+        heads: int = 5,
+        dropout: float = 0,
+        dropout_attn_score: float = 0.2,
+        drop_atom: float = 0,
+        drop_residue: float = 0,
+        dropout_cluster_edge: float = 0,
+        gaussian_noise: float = 0,
+        regression_head: bool = True,
+        classification_head: bool = False,
+        multiclassification_head: int = 0,
+        device: str = "cuda:0",
+    ):
+        super().__init__()
+
+        if aggregators is None:
+            aggregators = ["mean", "min", "max", "std"]
+        if scalers is None:
+            scalers = ["identity", "amplification", "linear"]
+        if K is None:
+            K = [5, 10, 20]
+
+        if not (regression_head or classification_head):
+            raise ValueError("Must have at least one objective head")
+
+        self.total_layer = total_layer
+        self.regression_head = regression_head
+        self.classification_head = classification_head
+        self.multiclassification_head = multiclassification_head
+
+        if isinstance(K, int):
+            K = [K] * total_layer
+        self.num_cluster = K
+
+        self.t = t
+        self.dropout = dropout
+        self.drop_atom = drop_atom
+        self.drop_residue = drop_residue
+        self.dropout_cluster_edge = dropout_cluster_edge
+        self.gaussian_noise = gaussian_noise
+        self.prot_edge_dim = hidden_channels
+        # NOTE: self.device removed — derive from input tensors in forward()
+        # Kept as init arg for API compat but not stored.
+
+        # Input encoders
+        self.atom_type_encoder = nn.Embedding(20, hidden_channels)
+        self.atom_feat_encoder = MLP(
+            [mol_in_channels, hidden_channels * 2, hidden_channels], out_norm=True
+        )
+        self.clique_encoder = nn.Embedding(4, hidden_channels)
+        self.prot_evo = MLP(
+            [prot_evo_channels, hidden_channels * 2, hidden_channels], out_norm=True
+        )
+        self.prot_aa = MLP(
+            [prot_in_channels, hidden_channels * 2, hidden_channels], out_norm=True
+        )
+
+        # Per-layer modules
+        self.mol_convs = nn.ModuleList()
+        self.prot_convs = nn.ModuleList()
+        self.mol_gn2 = nn.ModuleList()
+        self.prot_gn2 = nn.ModuleList()
+        self.inter_convs = nn.ModuleList()
+        self.cluster = nn.ModuleList()
+        self.mol_pools = nn.ModuleList()
+        self.mol_norms = nn.ModuleList()
+        self.prot_norms = nn.ModuleList()
+        self.atom_lins = nn.ModuleList()
+        self.residue_lins = nn.ModuleList()
+        self.c2a_mlps = nn.ModuleList()
+        self.c2r_mlps = nn.ModuleList()
+
+        for idx in range(total_layer):
+            self.mol_convs.append(
+                Drug_PNAConv(
+                    mol_deg,
+                    hidden_channels,
+                    edge_channels=hidden_channels,
+                    pre_layers=pre_layers,
+                    post_layers=post_layers,
+                    aggregators=aggregators,
+                    scalers=scalers,
+                    num_towers=heads,
+                    dropout=dropout,
+                )
+            )
+            self.prot_convs.append(
+                Protein_PNAConv(
+                    prot_deg,
+                    hidden_channels,
+                    edge_channels=hidden_channels,
+                    pre_layers=pre_layers,
+                    post_layers=post_layers,
+                    aggregators=aggregators,
+                    scalers=scalers,
+                    num_towers=heads,
+                    dropout=dropout,
+                )
+            )
+            self.cluster.append(
+                GCNCluster(
+                    [hidden_channels, hidden_channels * 2, K[idx]], in_norm=True
+                )
+            )
+            self.inter_convs.append(
+                DrugProteinConv(
+                    atom_channels=hidden_channels,
+                    residue_channels=hidden_channels,
+                    heads=heads,
+                    t=t,
+                    dropout_attn_score=dropout_attn_score,
+                )
+            )
+            self.mol_pools.append(
+                MotifPool(hidden_channels, heads, dropout_attn_score, drop_atom)
+            )
+            self.mol_norms.append(nn.LayerNorm(hidden_channels))
+            self.prot_norms.append(nn.LayerNorm(hidden_channels))
+            self.atom_lins.append(
+                nn.Linear(hidden_channels, hidden_channels, bias=False)
+            )
+            self.residue_lins.append(
+                nn.Linear(hidden_channels, hidden_channels, bias=False)
+            )
+            self.c2a_mlps.append(
+                MLP([hidden_channels, hidden_channels * 2, hidden_channels], bias=False)
+            )
+            self.c2r_mlps.append(
+                MLP([hidden_channels, hidden_channels * 2, hidden_channels], bias=False)
+            )
+            self.mol_gn2.append(GraphNorm(hidden_channels))
+            self.prot_gn2.append(GraphNorm(hidden_channels))
+
+        # Attention scoring
+        self.atom_attn_lin = PosLinear(
+            heads * total_layer, 1, bias=False, init_value=1 / heads
+        )
+        self.residue_attn_lin = PosLinear(
+            heads * total_layer, 1, bias=False, init_value=1 / heads
+        )
+
+        # Output heads
+        self.mol_out = MLP(
+            [hidden_channels, hidden_channels * 2, hidden_channels], out_norm=True
+        )
+        self.prot_out = MLP(
+            [hidden_channels, hidden_channels * 2, hidden_channels], out_norm=True
+        )
+        if self.regression_head:
+            self.reg_out = MLP([hidden_channels * 2, hidden_channels, 1])
+        if self.classification_head:
+            self.cls_out = MLP([hidden_channels * 2, hidden_channels, 1])
+        if self.multiclassification_head:
+            self.mcls_out = MLP(
+                [hidden_channels * 2, hidden_channels, multiclassification_head]
+            )
+
+    def reset_parameters(self):
+        self.atom_feat_encoder.reset_parameters()
+        self.prot_evo.reset_parameters()
+        self.prot_aa.reset_parameters()
+        for idx in range(self.total_layer):
+            self.mol_convs[idx].reset_parameters()
+            self.prot_convs[idx].reset_parameters()
+            self.mol_gn2[idx].reset_parameters()
+            self.prot_gn2[idx].reset_parameters()
+            self.cluster[idx].reset_parameters()
+            self.mol_pools[idx].reset_parameters()
+            self.mol_norms[idx].reset_parameters()
+            self.prot_norms[idx].reset_parameters()
+            self.inter_convs[idx].reset_parameters()
+            self.atom_lins[idx].reset_parameters()
+            self.residue_lins[idx].reset_parameters()
+            self.c2a_mlps[idx].reset_parameters()
+            self.c2r_mlps[idx].reset_parameters()
+        self.atom_attn_lin.reset_parameters()
+        self.residue_attn_lin.reset_parameters()
+        self.mol_out.reset_parameters()
+        self.prot_out.reset_parameters()
+        if self.regression_head:
+            self.reg_out.reset_parameters()
+        if self.classification_head:
+            self.cls_out.reset_parameters()
+        if self.multiclassification_head:
+            self.mcls_out.reset_parameters()
+
+    def forward(
+        self,
+        # Molecule
+        mol_x: Tensor,
+        mol_x_feat: Tensor,
+        bond_x: Tensor,
+        atom_edge_index: Tensor,
+        clique_x: Tensor,
+        clique_edge_index: Tensor,
+        atom2clique_index: Tensor,
+        # Protein
+        residue_x: Tensor,
+        residue_evo_x: Tensor,
+        residue_edge_index: Tensor,
+        residue_edge_weight: Tensor,
+        # Batch indices
+        mol_batch: Optional[Tensor] = None,
+        prot_batch: Optional[Tensor] = None,
+        clique_batch: Optional[Tensor] = None,
+        # Debug
+        save_cluster: bool = False,
+    ):
+        reg_pred = None
+        cls_pred = None
+        mcls_pred = None
+        device = mol_x.device
+
+        residue_edge_attr = _rbf(
+            residue_edge_weight,
+            D_max=1.0,
+            D_count=self.prot_edge_dim,
+        )
+
+        # Encode inputs
+        residue_x = self.prot_aa(residue_x) + self.prot_evo(residue_evo_x)
+        atom_x = self.atom_type_encoder(mol_x.squeeze()) + self.atom_feat_encoder(
+            mol_x_feat
+        )
+        clique_x = self.clique_encoder(clique_x.squeeze())
+
+        spectral_loss = torch.zeros((), device=device, dtype=torch.float32)
+        ortho_loss = torch.zeros((), device=device, dtype=torch.float32)
+        cluster_loss = torch.zeros((), device=device, dtype=torch.float32)
+        clique_scores = []
+        residue_scores = []
+        layer_s = {}
+
+        for idx in range(self.total_layer):
+            atom_x = self.mol_convs[idx](atom_x, bond_x, atom_edge_index)
+            residue_x = self.prot_convs[idx](
+                residue_x, residue_edge_index, residue_edge_attr
+            )
+
+            # Pool drug via motif attention
+            drug_x, clique_x, clique_score = self.mol_pools[idx](
+                atom_x, clique_x, atom2clique_index, clique_batch, clique_edge_index
+            )
+            drug_x = self.mol_norms[idx](drug_x)
+            clique_scores.append(clique_score)
+
+            # Cluster protein residues
+            dropped_edge_index, _ = _dropout_edge(
+                residue_edge_index,
+                p=self.dropout_cluster_edge,
+                force_undirected=True,
+                training=self.training,
+            )
+            s = self.cluster[idx](residue_x, dropped_edge_index)
+            residue_hx, residue_mask = to_dense_batch(residue_x, prot_batch)
+
+            if save_cluster:
+                layer_s[idx] = s
+
+            s, _ = to_dense_batch(s, prot_batch)
+            residue_adj = to_dense_adj(residue_edge_index, prot_batch)
+            cluster_mask = residue_mask
+
+            cluster_drop_mask = None
+            if self.drop_residue != 0 and self.training:
+                _, _, residue_drop_mask = _dropout_node(
+                    residue_edge_index,
+                    self.drop_residue,
+                    residue_x.size(0),
+                    prot_batch,
+                    self.training,
+                )
+                residue_drop_mask, _ = to_dense_batch(
+                    residue_drop_mask.reshape(-1, 1), prot_batch
+                )
+                residue_drop_mask = residue_drop_mask.squeeze()
+                cluster_drop_mask = residue_mask * residue_drop_mask.squeeze()
+
+            s, cluster_x, residue_adj, cl_loss, o_loss = dense_mincut_pool(
+                residue_hx, residue_adj, s, cluster_mask, cluster_drop_mask
+            )
+            ortho_loss += o_loss
+            cluster_loss += cl_loss
+            cluster_x = self.prot_norms[idx](cluster_x)
+
+            # Connect drug and protein cluster
+            batch_size = s.size(0)
+            num_k = self.num_cluster[idx]
+            cluster_residue_batch = torch.arange(
+                batch_size, device=device
+            ).repeat_interleave(num_k)
+            cluster_x = cluster_x.reshape(batch_size * num_k, -1)
+            p2m_edge_index = torch.stack([
+                torch.arange(batch_size * num_k, device=device),
+                cluster_residue_batch,
+            ])
+
+            # Cross-modal interaction
+            clique_x, cluster_x, inter_attn = self.inter_convs[idx](
+                drug_x, clique_x, clique_batch, cluster_x, p2m_edge_index
+            )
+            inter_attn = inter_attn[1]
+
+            # Residual: clique → atom
+            row, col = atom2clique_index
+            atom_x = atom_x + F.relu(
+                self.atom_lins[idx](
+                    scatter(
+                        clique_x[col],
+                        row,
+                        dim=0,
+                        dim_size=atom_x.size(0),
+                        reduce="mean",
+                    )
+                )
+            )
+            atom_x = atom_x + self.c2a_mlps[idx](atom_x)
+            atom_x = F.dropout(atom_x, self.dropout, training=self.training)
+
+            # Residual: cluster → residue
+            residue_hx, _ = to_dense_batch(cluster_x, cluster_residue_batch)
+            inter_attn, _ = to_dense_batch(inter_attn, cluster_residue_batch)
+            residue_x = residue_x + F.relu(
+                self.residue_lins[idx]((s @ residue_hx)[residue_mask])
+            )
+            residue_x = residue_x + self.c2r_mlps[idx](residue_x)
+            residue_x = F.dropout(residue_x, self.dropout, training=self.training)
+            inter_attn = (s @ inter_attn)[residue_mask]
+            residue_scores.append(inter_attn)
+
+            # Graph normalization
+            atom_x = self.mol_gn2[idx](atom_x, mol_batch)
+            residue_x = self.prot_gn2[idx](residue_x, prot_batch)
+
+        # Final pooling with learned attention
+        row, col = atom2clique_index
+        clique_scores = torch.cat(clique_scores, dim=-1)
+        atom_scores = scatter(
+            clique_scores[col], row, dim=0, dim_size=atom_x.size(0), reduce="mean"
+        )
+        atom_score = self.atom_attn_lin(atom_scores)
+        atom_score = softmax(atom_score, mol_batch)
+        mol_pool_feat = global_add_pool(atom_x * atom_score, mol_batch)
+
+        residue_scores = torch.cat(residue_scores, dim=-1)
+        residue_score = softmax(
+            self.residue_attn_lin(residue_scores), prot_batch
+        )
+        prot_pool_feat = global_add_pool(residue_x * residue_score, prot_batch)
+
+        mol_pool_feat = self.mol_out(mol_pool_feat)
+        prot_pool_feat = self.prot_out(prot_pool_feat)
+        mol_prot_feat = torch.cat([mol_pool_feat, prot_pool_feat], dim=-1)
+
+        if self.regression_head:
+            reg_pred = self.reg_out(mol_prot_feat)
+        if self.classification_head:
+            cls_pred = self.cls_out(mol_prot_feat)
+        if self.multiclassification_head:
+            mcls_pred = self.mcls_out(mol_prot_feat)
+
+        attention_dict = {
+            "residue_final_score": residue_score,
+            "atom_final_score": atom_score,
+            "clique_layer_scores": clique_scores,
+            "residue_layer_scores": residue_scores,
+            "drug_atom_index": mol_batch,
+            "drug_clique_index": clique_batch,
+            "protein_residue_index": prot_batch,
+            "mol_feature": mol_pool_feat,
+            "prot_feature": prot_pool_feat,
+            "interaction_fingerprint": mol_prot_feat,
+            "cluster_s": layer_s,
+        }
+
+        return (
+            reg_pred,
+            cls_pred,
+            mcls_pred,
+            spectral_loss,
+            ortho_loss,
+            cluster_loss,
+            attention_dict,
+        )

--- a/utils/ligand_init.py
+++ b/utils/ligand_init.py
@@ -445,10 +445,15 @@ def tree_decomposition(
 
 ###
 
-def smiles2graph(m_str):
-    mgd = MoleculeGraphDataset(halogen_detail=False)
+_DEFAULT_MGD = MoleculeGraphDataset(halogen_detail=False)
+
+
+def smiles2graph(m_str, mgd=None):
+    if mgd is None:
+        mgd = _DEFAULT_MGD
     mol = Chem.MolFromSmiles(m_str)
-    #mol = get_mol(m_str)
+    if mol is None:
+        raise ValueError(f"RDKit cannot parse SMILES: {m_str}")
     atom_feature, bond_feature = mgd.featurize(mol,'atom_full_feature')
     atom_idx, _ = mgd.featurize(mol,'atom_type')
     tree = mgd.junction_tree(mol)


### PR DESCRIPTION
## Summary

Adds `PSICHIC-prod/` — an optimized production inference pipeline for large-scale drug-protein screening on NVIDIA GPUs. The original `screening.py` and `models/` are **untouched**.

### New files (all under `PSICHIC-prod/`)
- **`inference.py`** — Production screening with LMDB ligand caching, batched ESM-2, multiprocessing, streaming top-K, AMP, and interpretation outputs
- **`psichic_model.py`** — Self-contained compile-friendly model (replaces `torch_scatter` with `torch_geometric.utils.scatter`)
- **`esm_batched/`** — Length-binned batched ESM-2 protein featurization with disk-cached `.pt` shards
- **`README.md`** — Usage guide with CLI flags and performance numbers

### Changed files (root)
- **`utils/ligand_init.py`** — `MoleculeGraphDataset` singleton (~3x speedup) + `mol is None` guard. Backward-compatible.

### Security hardening
- All `torch.load` use `weights_only=True` with `map_location="cpu"`
- LMDB cache uses `torch.save`/`torch.load` instead of `pickle`
- `tar.extract(filter="data")` + macOS `._*` filtering
- `assert` replaced with `if/raise RuntimeError`
- LMDB env `try/finally`, worker bytes serialization (no FD leaks)

### Performance (A100 80GB, Q16566 x 100K ZINC20)
| Stage | Original | PSICHIC-prod |
|-------|----------|--------------|
| Ligand featurization | ~335/s serial | **5,744/s** (62 workers) |
| LMDB cache hit | N/A | **instant** (0.4s for 98K) |
| Model scoring | ~55 pairs/s | **282 pairs/s** (AMP bs=128) |
| **Total 100K pairs** | ~30 min | **6 min** |

### Parity (multitask_PSICHIC, 100 pairs vs screening.py)
| Output | Max diff | Correlation |
|--------|----------|-------------|
| Regression | 0.013 | 0.99996 |
| Agonist | 0.010 | 0.99993 |
| Antagonist | 0.003 | 0.99998 |
| Nonbinder | 0.011 | 0.99995 |

## Test plan
- [x] Parity: multitask model, 100 pairs, all outputs match
- [x] E2E: 100K ZINC20, top-100, both model variants
- [x] LMDB cache: create + hit verified
- [x] macOS tar.gz resource fork filtering
- [x] Security: no pickle, weights_only, tar filter, LMDB try/finally